### PR TITLE
FI-1478: Fix patient id inputs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       ndjson (~> 1.0.0)
       rubyzip (~> 2.3.2)
       smart_app_launch_test_kit (= 0.1.1)
-      tls_test_kit (= 0.1.0)
+      tls_test_kit (= 0.1.1)
       us_core_test_kit (= 0.1.1)
 
 GEM
@@ -273,7 +273,7 @@ GEM
     sqlite3 (1.4.2)
     thor (1.1.0)
     tilt (2.0.10)
-    tls_test_kit (0.1.0)
+    tls_test_kit (0.1.1)
       inferno_core (> 0.1.3)
     transproc (1.1.1)
     tzinfo (2.0.4)

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ require 'pry-byebug'
 require_relative 'lib/inferno/terminology'
 require_relative 'lib/inferno/terminology/fhir_package_manager'
 require_relative 'lib/inferno/terminology/tasks'
-require_relative 'lib/onc_certification_g10_test_kit/tasks/generate_matrix'
 
 begin
   require 'rspec/core/rake_task'
@@ -130,6 +129,7 @@ end
 namespace :g10_test_kit do
   desc 'Generate ONC Certification (g)(10) Test Kit Matrix'
   task :generate_matrix do
+    require_relative 'lib/onc_certification_g10_test_kit/tasks/generate_matrix'
     ONCCertificationG10TestKit::Tasks::GenerateMatrix.new.run
   end
 end

--- a/config/presets/inferno_reference_server_preset.json
+++ b/config/presets/inferno_reference_server_preset.json
@@ -97,10 +97,10 @@
       "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
     },
     {
-      "name": "patient_ids",
+      "name": "additional_patient_ids",
       "type": "text",
-      "title": "Patient IDs",
-      "description": "Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements",
+      "title": "Additional Patient IDs",
+      "description": "Comma separated list of Patient IDs that together with the Patient ID from the SMART App Launch contain all MUST SUPPORT elements.",
       "value": "85,355"
     },
     {

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -4,6 +4,7 @@ require 'us_core_test_kit'
 require_relative 'onc_certification_g10_test_kit/configuration_checker'
 require_relative 'onc_certification_g10_test_kit/version'
 
+require_relative 'onc_certification_g10_test_kit/single_patient_api_group'
 require_relative 'onc_certification_g10_test_kit/smart_app_launch_invalid_aud_group'
 require_relative 'onc_certification_g10_test_kit/smart_invalid_launch_group'
 require_relative 'onc_certification_g10_test_kit/smart_invalid_token_group'
@@ -122,58 +123,7 @@ module ONCCertificationG10TestKit
 
     group from: 'g10_smart_ehr_practitioner_app'
 
-    group do
-      id :single_patient_api
-      title 'Single Patient API'
-      description %(
-        For each of the relevant USCDI data elements provided in the
-        CapabilityStatement, this test executes the [required supported
-        searches](http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html)
-        as defined by the US Core Implementation Guide v3.1.1. The test begins
-        by searching by one or more patients, with the expectation that the
-        Bearer token provided to the test grants access to all USCDI resources.
-        It uses results returned from that query to generate other queries and
-        checks that the results are consistent with the provided search
-        parameters. It then performs a read on each Resource returned and
-        validates the response against the relevant
-        [profile](http://www.hl7.org/fhir/us/core/STU3.1.1/profiles.html) as
-        currently defined in the US Core Implementation Guide. All MUST SUPPORT
-        elements must be seen before the test can pass, as well as Data Absent
-        Reason to demonstrate that the server can properly handle missing data.
-        Note that Encounter, Organization and Practitioner resources must be
-        accessible as references in some US Core profiles to satisfy must
-        support requirements, and those references will be validated to their US
-        Core profile. These resources will not be tested for FHIR search
-        support.
-      )
-      run_as_group
-
-      input :url,
-            title: 'FHIR Endpoint',
-            description: 'URL of the FHIR endpoint used by SMART applications'
-      input :smart_credentials,
-            title: 'SMART App Launch Credentials',
-            type: :oauth_credentials,
-            locked: true
-
-      fhir_client do
-        url :url
-        oauth_credentials :smart_credentials
-      end
-
-      USCoreTestKit::USCoreTestSuite.groups.each do |group|
-        test_group = group.ancestors[1]
-        id = test_group.id
-
-        group_config = {}
-        if test_group.respond_to?(:metadata) && test_group.metadata.delayed?
-          test_group.children.reject! { |child| child.include? USCoreTestKit::SearchTest }
-          group_config[:options] = { read_all_resources: true }
-        end
-
-        group(from: id, exclude_optional: true, config: group_config)
-      end
-    end
+    group from: 'g10_single_patient_api'
 
     group from: 'multi_patient_api'
 

--- a/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
@@ -83,6 +83,5 @@ module ONCCertificationG10TestKit
 
       group(from: id, exclude_optional: true, config: group_config)
     end
-
   end
 end

--- a/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
@@ -65,9 +65,9 @@ module ONCCertificationG10TestKit
             .map(&:presence)
             .compact
 
-        all_patient_ids = ([smart_app_launch_patient_id] + [additional_patient_ids_list]).compact
+        all_patient_ids = ([smart_app_launch_patient_id] + [additional_patient_ids_list]).compact.uniq
 
-        output patient_ids: all_patient_ids
+        output patient_ids: all_patient_ids.join(',')
       end
     end
 

--- a/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
@@ -1,0 +1,88 @@
+module ONCCertificationG10TestKit
+  class SinglePatientAPIGroup < Inferno::TestGroup
+    id :g10_single_patient_api
+    title 'Single Patient API'
+    description %(
+      For each of the relevant USCDI data elements provided in the
+      CapabilityStatement, this test executes the [required supported
+      searches](http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html)
+      as defined by the US Core Implementation Guide v3.1.1.
+
+      The test begins by searching by one or more patients, with the expectation
+      that the Bearer token provided to the test grants access to all USCDI
+      resources. It uses results returned from that query to generate other
+      queries and checks that the results are consistent with the provided
+      search parameters. It then performs a read on each Resource returned and
+      validates the response against the relevant
+      [profile](http://www.hl7.org/fhir/us/core/STU3.1.1/profiles.html) as
+      currently defined in the US Core Implementation Guide.
+
+      All MUST SUPPORT elements must be seen before the test can pass, as well
+      as Data Absent Reason to demonstrate that the server can properly handle
+      missing data. Note that Encounter, Organization and Practitioner resources
+      must be accessible as references in some US Core profiles to satisfy must
+      support requirements, and those references will be validated to their US
+      Core profile. These resources will not be tested for FHIR search support.
+    )
+    run_as_group
+
+    input :url,
+          title: 'FHIR Endpoint',
+          description: 'URL of the FHIR endpoint used by SMART applications'
+    input :patient_id,
+          title: 'Patient ID from SMART App Launch',
+          locked: true
+    input :additional_patient_ids,
+          title: 'Additional Patient IDs',
+          description: <<~DESCRIPTION,
+            Comma separated list of Patient IDs that together with the Patient
+            ID from the SMART App Launch contain all MUST SUPPORT elements.
+          DESCRIPTION
+          optional: true
+    input :smart_credentials,
+          title: 'SMART App Launch Credentials',
+          type: :oauth_credentials,
+          locked: true
+
+    fhir_client do
+      url :url
+      oauth_credentials :smart_credentials
+    end
+
+    test do
+      id :g10_patient_id_setup
+      title 'Manage patient id list'
+
+      input :patient_id, :additional_patient_ids
+      output :patient_ids
+
+      run do
+        smart_app_launch_patient_id = patient_id.presence
+        additional_patient_ids_list =
+          additional_patient_ids
+            .split(',')
+            .map(&:strip)
+            .map(&:presence)
+            .compact
+
+        all_patient_ids = ([smart_app_launch_patient_id] + [additional_patient_ids_list]).compact
+
+        output patient_ids: all_patient_ids
+      end
+    end
+
+    USCoreTestKit::USCoreTestSuite.groups.each do |group|
+      test_group = group.ancestors[1]
+      id = test_group.id
+
+      group_config = {}
+      if test_group.respond_to?(:metadata) && test_group.metadata.delayed?
+        test_group.children.reject! { |child| child.include? USCoreTestKit::SearchTest }
+        group_config[:options] = { read_all_resources: true }
+      end
+
+      group(from: id, exclude_optional: true, config: group_config)
+    end
+
+  end
+end

--- a/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
@@ -65,7 +65,7 @@ module ONCCertificationG10TestKit
             .map(&:presence)
             .compact
 
-        all_patient_ids = ([smart_app_launch_patient_id] + [additional_patient_ids_list]).compact.uniq
+        all_patient_ids = ([smart_app_launch_patient_id] + additional_patient_ids_list).compact.uniq
 
         output patient_ids: all_patient_ids.join(',')
       end

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -199,10 +199,12 @@ module ONCCertificationG10TestKit
       title 'Set SMART Credentials to EHR Launch Credentials'
 
       input :ehr_smart_credentials, type: :oauth_credentials
-      output :smart_credentials
+      input :ehr_patient_id
+      output :smart_credentials, :patient_id
 
       run do
-        output smart_credentials: ehr_smart_credentials.to_s
+        output smart_credentials: ehr_smart_credentials.to_s,
+               patient_id: ehr_patient_id
       end
     end
   end

--- a/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
@@ -62,8 +62,9 @@ module ONCCertificationG10TestKit
           patient_id: { name: :limited_patient_id },
           access_token: { name: :limited_access_token },
           requested_scopes: { name: :limited_requested_scopes },
-          smart_authorization_url: { locked: true, title: 'SMART Authorization Url' }, # TODO: separate standalone/ehr discovery outputs
-          smart_token_url: { locked: true, title: 'SMART Token Url' }, # TODO: separate standalone/ehr discovery outputs
+          # TODO: separate standalone/ehr discovery outputs
+          smart_authorization_url: { locked: true, title: 'SMART Authorization Url' },
+          smart_token_url: { locked: true, title: 'SMART Token Url' },
           received_scopes: { name: :limited_received_scopes },
           smart_credentials: { name: :limited_smart_credentials }
         },

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -168,10 +168,12 @@ module ONCCertificationG10TestKit
       title 'Set SMART Credentials to Standalone Launch Credentials'
 
       input :standalone_smart_credentials, type: :oauth_credentials
-      output :smart_credentials
+      input :standalone_patient_id
+      output :smart_credentials, :patient_id
 
       run do
-        output smart_credentials: standalone_smart_credentials.to_s
+        output smart_credentials: standalone_smart_credentials.to_s,
+               patient_id: standalone_patient_id
       end
     end
   end

--- a/onc_certification_g10_test_kit.gemspec
+++ b/onc_certification_g10_test_kit.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'ndjson', '~> 1.0.0'
   spec.add_runtime_dependency 'rubyzip', '~> 2.3.2'
   spec.add_runtime_dependency 'smart_app_launch_test_kit', '0.1.1'
-  spec.add_runtime_dependency 'tls_test_kit', '0.1.0'
+  spec.add_runtime_dependency 'tls_test_kit', '0.1.1'
   spec.add_runtime_dependency 'us_core_test_kit', '0.1.1'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'

--- a/spec/onc_certification_g10_test_kit/bulk_data_authorization_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_authorization_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../lib/onc_certification_g10_test_kit/authorization_request
 RSpec.describe ONCCertificationG10TestKit::BulkDataAuthorization do
   let(:group) { Inferno::Repositories::TestGroups.new.find('bulk_data_authorization') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:test_session) { repo_create(:test_session, test_group_id: 'bulk_data_authorization') }
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'g10_certification') }
   let(:bulk_token_endpoint) { 'http://example.com/fhir' }
   let(:bulk_encryption_method) { 'ES384' }
   let(:bulk_scope) { 'system/Patient.read' }

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../lib/onc_certification_g10_test_kit/bulk_data_group_expor
 RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExport do
   let(:group) { Inferno::Repositories::TestGroups.new.find('bulk_data_group_export') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:test_session) { repo_create(:test_session, test_group_id: 'bulk_data_group_export') }
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'g10_certification') }
   let(:bulk_server_url) { 'https://example.com/fhir' }
   let(:bearer_token) { 'some_bearer_token_alphanumeric' }
   let(:group_id) { '1219' }

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -4,7 +4,7 @@ require 'NDJSON'
 RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
   let(:group) { Inferno::Repositories::TestGroups.new.find('bulk_data_group_export_validation') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:test_session) { repo_create(:test_session, test_group_id: 'bulk_data_group_export_validation') }
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'g10_certification') }
   let(:endpoint) { 'https://www.example.com' }
   let(:status_output) { "[{\"url\":\"#{endpoint}\"}]" }
   let(:bearer_token) { 'token' }


### PR DESCRIPTION
This branch adds an `additional_patient_ids` input. The standalone and ehr launches set `patient_id`. The user can input `additional_patient_ids`. `patient_id` and `additional_patient_ids` are combined into a single input `patient_ids` which is passed along to the single patient api tests.