### PR TITLE
Omit location medication

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
@@ -456,7 +456,7 @@ module ONCCertificationG10TestKit
     test do
       title 'Medication resources returned conform to the US Core Medication Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any Medication resources.#{' '}
+        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any Medication resources.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication'
 

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
@@ -438,7 +438,7 @@ module ONCCertificationG10TestKit
     test do
       title 'Location resources returned conform to the US Core Location Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any Location resources.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-location'
 
@@ -456,7 +456,7 @@ module ONCCertificationG10TestKit
     test do
       title 'Medication resources returned conform to the US Core Medication Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any Medication resources. 
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication'
 

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
@@ -456,7 +456,7 @@ module ONCCertificationG10TestKit
     test do
       title 'Medication resources returned conform to the US Core Medication Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any Medication resources. 
+        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any Medication resources.#{' '}
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication'
 

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
@@ -436,7 +436,8 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'Location resources returned conform to the US Core Location Profile'
+      title 'Location resources returned conform to the HL7 FHIR Specification Location Resource if bulk data export' \
+            ' has Location resources'
       description <<~DESCRIPTION
         This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any Location resources.
       DESCRIPTION
@@ -454,7 +455,8 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'Medication resources returned conform to the US Core Medication Profile'
+      title 'Medication resources returned conform to the US Core Medication Profile if bulk data export has' \
+            ' Medication resources'
       description <<~DESCRIPTION
         This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any Medication resources.
       DESCRIPTION

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -156,11 +156,6 @@ module ONCCertificationG10TestKit
       line_count
     end
 
-    def omit_or_skip(message)
-      omit_if (OMIT_KLASS.include? resource_type), message
-      skip message
-    end
-
     def perform_bulk_export_validation
       skip_if status_output.blank?, 'Could not verify this functionality when Bulk Status Output is not provided'
       skip_if (requires_access_token == 'true' && bearer_token.blank?),
@@ -168,7 +163,10 @@ module ONCCertificationG10TestKit
 
       file_list = JSON.parse(status_output).select { |file| file['type'] == resource_type }
       message = "No #{resource_type} resource file item returned by server."
-      omit_or_skip(message) if file_list.empty?
+      if file_list.empty?
+        omit_if (OMIT_KLASS.include? resource_type), message
+        skip message
+      end
 
       success_count = 0
       file_list.each do |file|

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -163,8 +163,8 @@ module ONCCertificationG10TestKit
               'Could not verify this functionality when Bearer Token is required and not provided'
 
       file_list = JSON.parse(status_output).select { |file| file['type'] == resource_type }
-      message = "No #{resource_type} resource file item returned by server."
       if file_list.empty?
+        message = "No #{resource_type} resource file item returned by server."
         omit_if (OMIT_KLASS.include? resource_type), message
         skip message
       end

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -129,10 +129,8 @@ module ONCCertificationG10TestKit
         end
 
         if resource.resourceType != resource_type
-          message = "Resource type \"#{resource.resourceType}\" at line \"#{line_count}\" does not match type" \
-                    " defined in output \"#{resource_type}\""
-          omit_if (OMIT_KLASS.include? resource_type), message
-          assert false, message
+          assert false, "Resource type \"#{resource.resourceType}\" at line \"#{line_count}\" does not match type" \
+                        " defined in output \"#{resource_type}\""
         end
 
         profile_url = determine_profile(resource)

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -131,7 +131,8 @@ module ONCCertificationG10TestKit
         if resource.resourceType != resource_type
           message = "Resource type \"#{resource.resourceType}\" at line \"#{line_count}\" does not match type" \
                     " defined in output \"#{resource_type}\""
-          omit_or_skip message
+          omit_if (OMIT_KLASS.include? resource_type), message
+          assert false, message
         end
 
         profile_url = determine_profile(resource)

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -98,6 +98,8 @@ module ONCCertificationG10TestKit
 
     def validate_conformance(resources)
       metadata_list.each do |meta|
+        next if resource_type == 'Location'
+
         skip_if resources[meta.profile_url].blank?,
                 "No #{resource_type} resources found that conform to profile: #{meta.profile_url}."
         @metadata = meta
@@ -137,8 +139,9 @@ module ONCCertificationG10TestKit
         resources[profile_url] << resource
         scratch[:patient_ids_seen] = patient_ids_seen | [resource.id] if resource_type == 'Patient'
 
-        skip_if !resource_is_valid?(resource: resource, profile_url: profile_url),
-                "Resource at line \"#{line_count}\" does not conform to profile \"#{profile_url}\"."
+        unless resource_is_valid?(resource: resource, profile_url: profile_url)
+          assert false, "Resource at line \"#{line_count}\" does not conform to profile \"#{profile_url}\"."
+        end
       }
 
       process_headers = proc { |response|

--- a/lib/onc_certification_g10_test_kit/profile_guesser.rb
+++ b/lib/onc_certification_g10_test_kit/profile_guesser.rb
@@ -1,10 +1,13 @@
 module ONCCertificationG10TestKit
   module ProfileGuesser
     def extract_profile(profile)
-      if ['Location', 'Medication'].include?(profile)
+      case profile
+      when 'Medication'
         return USCoreTestKit::USCoreTestSuite.metadata.find do |meta|
                  meta.resource == profile
                end.profile_url
+      when 'Location'
+        return 'http://hl7.org/fhir/StructureDefinition/Location'
       end
       "USCoreTestKit::#{profile}Group".constantize.metadata.profile_url
     end

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -510,7 +510,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       expect(result.result_message).to eq('No Location resource file item returned by server.')
     end
 
-    it 'omits when non Location resources are returned' do
+    it 'fails when non Location resources are returned' do
       stub_request(:get, endpoint)
         .with(headers: { 'Accept' => 'application/fhir+ndjson' })
         .to_return(status: 200, body: not_location_contents, headers: headers)
@@ -518,7 +518,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       allow_any_instance_of(runnable).to receive(:resource_is_valid?).and_return(true)
       result = run(runnable, location_input)
 
-      expect(result.result).to eq('omit')
+      expect(result.result).to eq('fail')
       expect(result.result_message)
         .to eq('Resource type "Device" at line "1" does not match type defined in output "Location"')
     end
@@ -574,7 +574,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       expect(result.result_message).to eq('No Medication resource file item returned by server.')
     end
 
-    it 'omits when the returned resources are not of the expected profile' do
+    it 'fails when the returned resources are not of the expected profile' do
       stub_request(:get, endpoint)
         .with(headers: { 'Accept' => 'application/fhir+ndjson' })
         .to_return(status: 200, body: not_medication_contents, headers: headers)
@@ -582,7 +582,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       allow_any_instance_of(runnable).to receive(:resource_is_valid?).and_return(true)
       result = run(runnable, medication_input)
 
-      expect(result.result).to eq('omit')
+      expect(result.result).to eq('fail')
       expect(result.result_message)
         .to eq('Resource type "Device" at line "1" does not match type defined in output "Medication"')
     end

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -494,11 +494,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
     let(:not_location_contents) { '' }
 
     before do
-      resources.each do |resource|
-        contents << ("#{resource.to_json}\n")
-        resource['status'] = nil
-        contents_missing_element << ("#{resource.to_json.gsub(/[ \n]/, '')}\n")
-      end
+      resources.each { |resource| contents << ("#{resource.to_json}\n") }
       not_location_resource.each { |resource| not_location_contents << ("#{resource.to_json}\n") }
     end
 
@@ -521,19 +517,6 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       expect(result.result).to eq('fail')
       expect(result.result_message)
         .to eq('Resource type "Device" at line "1" does not match type defined in output "Location"')
-    end
-
-    it 'skips when returned resources are missing a must support slice' do
-      stub_request(:get, endpoint)
-        .with(headers: { 'Accept' => 'application/fhir+ndjson' })
-        .to_return(status: 200, body: contents_missing_element, headers: headers)
-
-      allow_any_instance_of(runnable).to receive(:resource_is_valid?).and_return(true)
-      result = run(runnable, location_input)
-
-      expect(result.result).to eq('skip')
-      expect(result.result_message)
-        .to eq('Could not find status in the 5 provided Location resource(s)')
     end
 
     it 'passes when the returned resources are fully conformant' do

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -254,13 +254,13 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
         .with_message('Resource type "Encounter" at line "1" does not match type defined in output "Patient"')
     end
 
-    it 'skips when returned contents is not valid for the expected resource type' do
+    it 'fails when returned contents is not valid for the expected resource type' do
       stub_request(:get, url)
         .to_return(status: 200, headers: headers, body: patient_contents)
 
       allow(tester).to receive(:resource_is_valid?).and_return(false)
       expect { tester.check_file_request(url) }
-        .to raise_exception(Inferno::Exceptions::SkipException)
+        .to raise_exception(Inferno::Exceptions::AssertionException)
         .with_message('Resource at line "1" does not conform to profile "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient".')
     end
 
@@ -364,7 +364,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
 
     it "returns Location's profile when given a Location resource" do
       result = tester.determine_profile(FHIR::Location.new)
-      expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-location')
+      expect(result).to eq('http://hl7.org/fhir/StructureDefinition/Location')
     end
 
     it "returns Medications's profile when given a Medication resource" do

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -245,12 +245,12 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
         .with_message('Server response at line "1" is not a processable FHIR resource.')
     end
 
-    it 'skips when returned contents is not of the expected resource type' do
+    it 'fails when returned contents is not of the expected resource type' do
       stub_request(:get, url)
         .to_return(status: 200, headers: headers, body: encounter_contents)
 
       expect { tester.check_file_request(url) }
-        .to raise_exception(Inferno::Exceptions::SkipException)
+        .to raise_exception(Inferno::Exceptions::AssertionException)
         .with_message('Resource type "Encounter" at line "1" does not match type defined in output "Patient"')
     end
 


### PR DESCRIPTION
Allow Medication and Location tests in Bulk Data Export Validation to omit instead of skip if the respective resources are not returned. 