### PR TITLE
Reformat line breaks in input description

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_data_authorization.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_authorization.rb
@@ -21,8 +21,9 @@ module ONCCertificationG10TestKit
 
     input :bulk_token_endpoint,
           title: 'Backend Services Token Endpoint',
-          description: 'The OAuth 2.0 Token Endpoint used by the Backend Services specification
-                        to provide bearer tokens.'
+          description: <<~DESCRIPTION,
+            The OAuth 2.0 Token Endpoint used by the Backend Services specification to provide bearer tokens.
+          DESCRIPTION
     input :bulk_client_id,
           title: 'Bulk Data Client ID',
           description: 'Client ID provided at registration to the Inferno application.'
@@ -32,8 +33,10 @@ module ONCCertificationG10TestKit
           default: 'system/*.read'
     input :bulk_encryption_method,
           title: 'Encryption Method',
-          description: 'The server is required to suport either ES384 or RS384 encryption methods
-                        for JWT signature verification. Select which method to use.',
+          description: <<~DESCRIPTION, 
+            The server is required to suport either ES384 or RS384 encryption methods for JWT signature verification. 
+            Select which method to use.
+          DESCRIPTION
           type: 'radio',
           default: 'ES384',
           options: {

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export.rb
@@ -19,11 +19,12 @@ module ONCCertificationG10TestKit
           description: 'The Group ID associated with the group of patients to be exported.'
     input :bulk_timeout,
           title: 'Export Times Out after (1-600)',
-          description: 'While testing, Inferno waits for the server to complete the exporting task.
-          If the calculated totalTime is greater than the timeout value specified here,
-          Inferno bulk client stops testing. Please enter an integer for the maximum wait time in seconds.
-          If timeout is less than 1, Inferno uses default value 180.
-          If the timeout is greater than 600 (10 minutes), Inferno uses the maximum value 600.',
+          description: <<~DESCRIPTION,
+            While testing, Inferno waits for the server to complete the exporting task. If the calculated totalTime is
+            greater than the timeout value specified here, Inferno bulk client stops testing. Please enter an integer
+            for the maximum wait time in seconds. If timeout is less than 1, Inferno uses default value 180. If the 
+              timeout is greater than 600 (10 minutes), Inferno uses the maximum value 600.
+          DESCRIPTION
           default: 180
 
     output :requires_access_token, :status_output, :bulk_download_url

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
@@ -17,14 +17,18 @@ module ONCCertificationG10TestKit
           optional: true
     input :bulk_patient_ids_in_group,
           title: 'Patient IDs in exported Group',
-          description: 'Comma separated list of every Patient ID that is in the specified Group. This information is
-          provided by the system under test to verify that data returned matches expectations. Leave blank to not
-          verify Group inclusion.'
+          description: <<~DESCRIPTION,
+            Comma separated list of every Patient ID that is in the specified Group. This information is provided by
+            the system under test to verify that data returned matches expectations. Leave blank to not verify Group
+            inclusion.
+          DESCRIPTION
     input :bulk_device_types_in_group,
           title: 'Implantable Device Type Codes in exported Group',
-          description: 'Comma separated list of every Implantable Device type that is in the specified Group. This
-          information is provided by the system under test to verify that data returned matches expectations. Leave
-          blank to verify all Device resources against the Implantable Device profile.',
+          description: <<~DESCRIPTION, 
+            Comma separated list of every Implantable Device type that is in the specified Group. This information is
+            provided by the system under test to verify that data returned matches expectations. Leave blank to verify
+            all Device resources against the Implantable Device profile.
+          DESCRIPTION
           optional: true
 
     test from: :tls_version_test do


### PR DESCRIPTION
In the current state, some ugly '\n' get shown in JSON/YAML representation. This fixes that.  