### PR TITLE
Relax regex on bulk data server group export url

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export.rb
@@ -73,7 +73,7 @@ module ONCCertificationG10TestKit
             resource.type == 'Group' &&
               resource.respond_to?(:operation) &&
               resource.operation&.find do |operation|
-                name_match = operation.name == 'export'
+                name_match = ['export', 'group-export'].include?(operation.name)
                 if name_match && !operation.definition&.match(%r{^http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export(\|\S+)?$})
                   info('Server CapabilityStatement does not include export operation with definition http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export')
                 end

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export.rb
@@ -73,7 +73,12 @@ module ONCCertificationG10TestKit
             resource.type == 'Group' &&
               resource.respond_to?(:operation) &&
               resource.operation&.find do |operation|
-                operation.definition&.match(%r{^http(s)?://.*/OperationDefinition/group-export(\|\S+)?$})
+                name_match = operation.name == 'export'
+                if name_match && !operation.definition&.match(%r{^http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export(\|\S+)?$})
+                  info('Server CapabilityStatement does not include export operation with definition http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export')
+                end
+
+                name_match
               end
           end
         end

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export.rb
@@ -73,7 +73,7 @@ module ONCCertificationG10TestKit
             resource.type == 'Group' &&
               resource.respond_to?(:operation) &&
               resource.operation&.find do |operation|
-                operation.definition&.match(%r{^http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export(\|\S+)?})
+                operation.definition&.match(%r{^http(s)?://.*/OperationDefinition/group-export(\|\S+)?$})
               end
           end
         end

--- a/spec/fixtures/CapabilityStatement.json
+++ b/spec/fixtures/CapabilityStatement.json
@@ -1,1 +1,116 @@
-{"resourceType":"CapabilityStatement","status":"active","date":"2021-11-18T19:22:48+00:00","publisher":"Boston Children's Hospital","kind":"instance","instantiates":["http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data"],"software":{"name":"SMART Sample Bulk Data Server","version":"2.1.1"},"implementation":{"description":"SMART Sample Bulk Data Server"},"fhirVersion":"4.0.1","acceptUnknown":"extensions","format":["json"],"rest":[{"mode":"server","security":{"extension":[{"url":"http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris","extension":[{"url":"token","valueUri":"https://inferno.healthit.gov/bulk-data-server/auth/token"},{"url":"register","valueUri":"https://inferno.healthit.gov/bulk-data-server/auth/register"}]}],"service":[{"coding":[{"system":"http://hl7.org/fhir/restful-security-service","code":"SMART-on-FHIR","display":"SMART-on-FHIR"}],"text":"OAuth2 using SMART-on-FHIR profile (see http://docs.smarthealthit.org)"}]},"resource":[{"type":"Patient","operation":[{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation","valueCode":"SHOULD"}],"name":"patient-export","definition":"http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export"}]},{"type":"Group","operation":[{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation","valueCode":"SHOULD"}],"name":"group-export","definition":"http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export"}]},{"type":"OperationDefinition","profile":{"reference":"http://hl7.org/fhir/Profile/OperationDefinition"},"interaction":[{"code":"read"}],"searchParam":[]}],"operation":[{"name":"get-resource-counts","definition":"OperationDefinition/-s-get-resource-counts"},{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation","valueCode":"SHOULD"}],"name":"export","definition":"http://hl7.org/fhir/uv/bulkdata/OperationDefinition/export"}]}]}
+{
+  "resourceType": "CapabilityStatement",
+  "status": "active",
+  "date": "2021-11-18T19:22:48+00:00",
+  "publisher": "Boston Children's Hospital",
+  "kind": "instance",
+  "instantiates": [
+    "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data"
+  ],
+  "software": {
+    "name": "SMART Sample Bulk Data Server",
+    "version": "2.1.1"
+  },
+  "implementation": {
+    "description": "SMART Sample Bulk Data Server"
+  },
+  "fhirVersion": "4.0.1",
+  "acceptUnknown": "extensions",
+  "format": [
+    "json"
+  ],
+  "rest": [
+    {
+      "mode": "server",
+      "security": {
+        "extension": [
+          {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris",
+            "extension": [
+              {
+                "url": "token",
+                "valueUri": "https://inferno.healthit.gov/bulk-data-server/auth/token"
+              },
+              {
+                "url": "register",
+                "valueUri": "https://inferno.healthit.gov/bulk-data-server/auth/register"
+              }
+            ]
+          }
+        ],
+        "service": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/restful-security-service",
+                "code": "SMART-on-FHIR",
+                "display": "SMART-on-FHIR"
+              }
+            ],
+            "text": "OAuth2 using SMART-on-FHIR profile (see http://docs.smarthealthit.org)"
+          }
+        ]
+      },
+      "resource": [
+        {
+          "type": "Patient",
+          "operation": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient-export",
+              "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export"
+            }
+          ]
+        },
+        {
+          "type": "Group",
+          "operation": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "export",
+              "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export"
+            }
+          ]
+        },
+        {
+          "type": "OperationDefinition",
+          "profile": {
+            "reference": "http://hl7.org/fhir/Profile/OperationDefinition"
+          },
+          "interaction": [
+            {
+              "code": "read"
+            }
+          ],
+          "searchParam": []
+        }
+      ],
+      "operation": [
+        {
+          "name": "get-resource-counts",
+          "definition": "OperationDefinition/-s-get-resource-counts"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "name": "export",
+          "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/export"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_spec.rb
@@ -79,7 +79,17 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExport do
         .to eq('Server CapabilityStatement did not declare support for export operation in Group resource')
     end
 
-    it 'passes when server declares support in CapabilityStatement' do
+    it 'passes when server declares support export in CapabilityStatement' do
+      stub_request(:get, "#{bulk_server_url}/metadata")
+        .to_return(status: 200, body: capability_statement.to_json)
+
+      result = run(runnable, base_input)
+
+      expect(result.result).to eq('pass')
+    end
+
+    it 'passes when server declares support group-export in CapabilityStatement' do
+      capability_statement.rest.first.resource[1].operation.first.name = 'group-export'
       stub_request(:get, "#{bulk_server_url}/metadata")
         .to_return(status: 200, body: capability_statement.to_json)
 

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExport do
       capability_statement_json['rest'][0]['resource'][1]['operation'][0]['definition'] += '|1.0.1'
       capability_statement_json.to_json
     end
+    let(:capability_with_custom_base_url) do
+      capability_statement_json = JSON.parse(capability_statement)
+      capability_statement_json['rest'][0]['resource'][1]['operation'][0]['definition'] = 'https://example.org/fhir/uv/bulkdata/OperationDefinition/group-export|1.0.1'
+      capability_statement_json.to_json
+    end
 
     it 'fails when CapabilityStatement can not be retrieved' do
       stub_request(:get, "#{bulk_server_url}/metadata")
@@ -99,6 +104,15 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExport do
     it 'passes when server declares support with version in CapabilityStatement' do
       stub_request(:get, "#{bulk_server_url}/metadata")
         .to_return(status: 200, body: capability_statement_with_version)
+
+      result = run(runnable, base_input)
+
+      expect(result.result).to eq('pass')
+    end
+
+    it 'has an operation definition URL for group-export' do
+      stub_request(:get, "#{bulk_server_url}/metadata")
+        .to_return(status: 200, body: capability_with_custom_base_url)
 
       result = run(runnable, base_input)
 

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExport do
       group_id: group_id
     }
   end
-  let(:capability_statement) { File.read('spec/fixtures/CapabilityStatement.json') }
+  let(:capability_statement) { FHIR.from_contents(File.read('spec/fixtures/CapabilityStatement.json')) }
   let(:status_response) do
     '{"transactionTime":"2021-11-30T13:40:29.828Z","request":"https://inferno.healthit.gov/bulk-data-server/' \
       'eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0Ijo2MCwibSI6MSwic3R1Ijo0LCJkZWwiOjB9/fhir/Group/' \


### PR DESCRIPTION
Reported issue about having a server on a url that does not match our reference server and hardcoded fixtures.  I'm not sure how much of this URL is the _"base"_.

This is the regex: `%r{^http(s)?://.*/OperationDefinition/group-export(\|\S+)?$}`

Added a test, watched it pass/flip both ways on http|https, version number at the end, before this PR, the whole red/green loop.  So I'm confident in this fix but not on what we want to consider the base url.

Related: #51