### PR TITLE
FI-1510: Fix terminology build issues

### DIFF
--- a/Dockerfile.terminology
+++ b/Dockerfile.terminology
@@ -1,7 +1,7 @@
 FROM ruby:2.7.2
 
 ENV INSTALL_PATH=/opt/inferno/
-
+ENV APP_ENV=production
 RUN mkdir -p $INSTALL_PATH
 
 WORKDIR $INSTALL_PATH

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Prerequisites:
     requirement to around 40 GB.
 * A copy of the Inferno repository, which contains the required Docker and Ruby
   files
+* Run `setup.sh` to initialize Inferno's database
 
 You can prebuild the terminology docker container by running the following
 command:

--- a/Rakefile
+++ b/Rakefile
@@ -106,7 +106,7 @@ namespace :terminology do |_argv|
 
   desc 'Download FHIR Package'
   task :download_package, [:package, :location] do |_t, args|
-    Inferno::FHIRPackageManager.get_package(args.package, args.location)
+    Inferno::Terminology::FHIRPackageManager.get_package(args.package, args.location)
   end
 
   desc 'Download Terminology from FHIR Package'

--- a/lib/inferno/terminology/tasks/check_built_terminology.rb
+++ b/lib/inferno/terminology/tasks/check_built_terminology.rb
@@ -4,9 +4,11 @@ module Inferno
   module Terminology
     module Tasks
       class CheckBuiltTerminology
-        MIME_TYPE_SYSTEMS = [
+        NON_UMLS_SYSTEMS = [
           'http://hl7.org/fhir/ValueSet/mimetypes',
-          'urn:ietf:bcp:13'
+          'urn:ietf:bcp:13',
+          'http://hl7.org/fhir/us/core/ValueSet/simple-language',
+          'urn:ietf:bcp:47'
         ].freeze
 
         def run
@@ -15,16 +17,16 @@ module Inferno
             return
           end
 
-          if only_mime_types_mismatch?
-            Inferno.logger.info <<~MIME
+          if only_non_umls_mismatch?
+            Inferno.logger.info <<~NON_UMLS
               Terminology built successfully.
 
-              Mime-type based terminology did not match, but this can be a
-              result of using a newer version of the `mime-types-data` gem and
-              does not necessarily reflect a problem with the terminology build.
-              The expected mime-types codes were generated with version
-              `mime-types-data` version `3.2021.0901`.
-            MIME
+              Some terminology not based on UMLS did not match, but this can be
+              a result of these terminologies having a different update schedule
+              than UMLS. As long as the actual number of codes is close to the
+              expected number, this does not does not reflect a problem with the
+              terminology build.
+            NON_UMLS
           else
             Inferno.logger.info 'Terminology build results different than expected.'
           end
@@ -61,8 +63,8 @@ module Inferno
           new_manifest.find { |value_set| value_set[:url] == url }
         end
 
-        def only_mime_types_mismatch?
-          mismatched_value_sets.all? { |value_set| MIME_TYPE_SYSTEMS.include? value_set[:url] }
+        def only_non_umls_mismatch?
+          mismatched_value_sets.all? { |value_set| NON_UMLS_SYSTEMS.include? value_set[:url] }
         end
 
         def mismatched_value_set_message(expected_value_set)

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -55,7 +55,7 @@ module ONCCertificationG10TestKit
           success_messages << "* `#{url}`: #{actual_value_set[:count]} codes"
         elsif actual_value_set.nil?
           error_messages << "* `#{url}`: Not loaded"
-        elsif terminology_checker.class::MIME_TYPE_SYSTEMS.include? url
+        elsif terminology_checker.class::NON_UMLS_SYSTEMS.include? url
           warning_messages <<
             "* `#{url}`: Expected codes: #{expected_value_set[:count]} Actual codes: #{actual_value_set[:count]}"
         else
@@ -74,10 +74,11 @@ module ONCCertificationG10TestKit
 
       if warning_messages.present?
         warning_message = <<~WARNING
-          Mime-type based terminology did not exactly match. This can be the
-          result of using a slightly different version of the `mime-types-data`
-          gem and does not reflect a problem with the terminology build as long
-          as the expected and actual number of codes are close to each other.
+          Some terminology not based on UMLS did not match, but this can be a
+          result of these terminologies having a different update schedule than
+          UMLS. As long as the actual number of codes is close to the expected
+          number, this does not does not reflect a problem with the terminology
+          build.
         WARNING
         messages << {
           type: 'warning',


### PR DESCRIPTION
This PR addresses terminology issues raised in #54 and #61:
- update the terminology docker image to run in production mode so that it can access the database created by `setup.sh`
- update the terminology instructions to include running `setup.sh`
- update the list of terminologies which can't be exactly checked to include the language terminologies in addition to the mime-type terminologies