### PR TITLE
FI-1519: Add tmp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 /data/*.db-journal
 /data/redis/*.rdb
 /data/redis/*.aof
-/tmp
+/tmp/*
+!/tmp/.keep
 .env.local
 .env.*.local
 **/.DS_Store


### PR DESCRIPTION
Make sure `tmp` folder exists to avoid terminology build error (#68).