### PR TITLE
Update title and description for one visaul inspection test

### DIFF
--- a/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
+++ b/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
@@ -144,13 +144,14 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'Health IT Module attested that refresh tokens are valid for a period of no shorter than three months.'
+      title 'Health IT Module attested that it is capable of issuing refresh tokens / '\
+            'that are valid for a period of no shorter than three months.'
       description %(
-        Health IT Module attested that refresh tokens are valid for a period of
-        no shorter than three months.
+        Health IT Module attested that it is capable of issuing refresh tokens
+        that are valid for a period of no shorter than three months.
       )
       input :refresh_token_period_attestation,
-            title: 'Health IT Module attested that refresh tokens are valid for a period of no shorter than three months.', # rubocop:disable Layout/LineLength
+            title: 'Health IT Module attested that it is capable of issuing refresh tokens that are valid for a period of no shorter than three months.', # rubocop:disable Layout/LineLength
             type: 'radio',
             default: 'false',
             options: {
@@ -172,8 +173,8 @@ module ONCCertificationG10TestKit
 
       run do
         assert refresh_token_period_attestation == 'true',
-               'Health IT Module did not attest that refresh tokens are valid ' \
-               'for a period of no shorter than three months.'
+               'Health IT Module did not attest that it is capable of issuing refresh tokens / ' \
+               'that are valid for a period of no shorter than three months.'
         pass refresh_token_period_notes if refresh_token_period_notes.present?
       end
     end

--- a/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
+++ b/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
@@ -173,7 +173,7 @@ module ONCCertificationG10TestKit
 
       run do
         assert refresh_token_period_attestation == 'true',
-               'Health IT Module did not attest that it is capable of issuing refresh tokens / ' \
+               'Health IT Module did not attest that it is capable of issuing refresh tokens ' \
                'that are valid for a period of no shorter than three months.'
         pass refresh_token_period_notes if refresh_token_period_notes.present?
       end

--- a/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
+++ b/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
@@ -144,7 +144,7 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'Health IT Module attested that it is capable of issuing refresh tokens / '\
+      title 'Health IT Module attested that it is capable of issuing refresh tokens ' \
             'that are valid for a period of no shorter than three months.'
       description %(
         Health IT Module attested that it is capable of issuing refresh tokens


### PR DESCRIPTION
This PR updates title and description of Visual Inspection and Attestation test 6.6.05/ATT-05 

from:
Health IT Module attested that refresh tokens are valid for a period of no shorter than three months.

to:
Health IT Module attested that it is capable of issuing refresh tokens  that are valid for a period of no shorter than three months.

This  PR fixes Github Issue #45 