### PR TITLE
FI-1522 Accept Redirect 301/302/303/307 for Bulk Data file download

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -58,7 +58,7 @@ module ONCCertificationG10TestKit
       headers
     end
 
-    def stream_ndjson(endpoint, headers, process_chunk_line, process_response)
+    def stream_ndjson(endpoint, headers, process_chunk_line, process_response) # rubocop:disable Metrics/CyclomaticComplexity
       hanging_chunk = String.new
 
       process_body = proc { |chunk|
@@ -155,7 +155,7 @@ module ONCCertificationG10TestKit
         scratch[:patient_ids_seen] = patient_ids_seen | [resource.id] if resource_type == 'Patient'
 
         unless resource_is_valid?(resource: resource, profile_url: profile_url)
-         assert false, "Resource at line \"#{line_count}\" does not conform to profile \"#{profile_url}\"."
+          assert false, "Resource at line \"#{line_count}\" does not conform to profile \"#{profile_url}\"."
         end
       }
 

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -87,6 +87,8 @@ module ONCCertificationG10TestKit
         redirect_headers = headers.reject { |key, _value| key == :authorization }
 
         stream(process_body, redirect_url, headers: redirect_headers)
+
+        redirect_url = request.response_header('location')&.value
       end
 
       process_chunk_line.call(hanging_chunk)

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -608,15 +608,14 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
 
       it 'accepts multiple redirect' do
         redirect_url = 'http://example.com/redirect'
-        redirect_url_2 = 'http://example.com/redirect_2'
-
+        redirect_url2 = 'http://example.com/redirect_2'
 
         stub_request(:get, url.to_s)
           .with(headers: headers_with_authorization)
           .to_return(status: 301, headers: { 'location' => redirect_url })
         stub_request(:get, redirect_url)
           .with(headers: headers_without_authorization)
-          .to_return(status: 307, headers: { 'location' => redirect_url_2 })
+          .to_return(status: 307, headers: { 'location' => redirect_url2 })
         stub_request(:get, redirect_url_2)
           .with(headers: headers_without_authorization)
           .to_return(status: 200)

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -606,7 +606,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
         expect(tester.response[:status]).to eq(200)
       end
 
-      it 'accepts multiple redirect' do
+      it 'accepts multiple redirects' do
         redirect_url = 'http://example.com/redirect'
         redirect_url2 = 'http://example.com/redirect_2'
 
@@ -616,7 +616,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
         stub_request(:get, redirect_url)
           .with(headers: headers_without_authorization)
           .to_return(status: 307, headers: { 'location' => redirect_url2 })
-        stub_request(:get, redirect_url_2)
+        stub_request(:get, redirect_url2)
           .with(headers: headers_without_authorization)
           .to_return(status: 200)
 

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -563,19 +563,18 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
       expect(streamed_chunks).to eq(["multi\n touched", "line\n touched", "response\n touched", "body\n touched"])
     end
 
-
-    context '301 redirect' do
-      let(:headers_with_authorization) {
+    context 'with redirect' do
+      let(:headers_with_authorization) do
         {
           accept: 'application/fhir+ndjson',
           authorization: "Bearer #{bearer_token}"
         }
-      }
-      let(:headers_without_authorization) {
+      end
+      let(:headers_without_authorization) do
         {
           accept: 'application/fhir+ndjson'
         }
-      }
+      end
       let(:redirect_url) { 'http://example.com/redirect' }
 
       it 'accepts 301 redirect' do

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -575,13 +575,49 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
           accept: 'application/fhir+ndjson'
         }
       end
-      let(:redirect_url) { 'http://example.com/redirect' }
 
       it 'accepts 301 redirect' do
+        redirect_url = 'http://example.com/redirect'
+
         stub_request(:get, url.to_s)
           .with(headers: headers_with_authorization)
           .to_return(status: 301, headers: { 'location' => redirect_url })
         stub_request(:get, redirect_url)
+          .with(headers: headers_without_authorization)
+          .to_return(status: 200)
+
+        tester.stream_ndjson(url, headers_with_authorization, process_line_block, generic_block)
+
+        expect(tester.response[:status]).to eq(200)
+      end
+
+      it 'accepts 301 redirect to relative url' do
+        redirect_url = 'relative_redirect'
+
+        stub_request(:get, url.to_s)
+          .with(headers: headers_with_authorization)
+          .to_return(status: 301, headers: { 'location' => redirect_url })
+        stub_request(:get, "#{url}/#{redirect_url}")
+          .with(headers: headers_without_authorization)
+          .to_return(status: 200)
+
+        tester.stream_ndjson(url, headers_with_authorization, process_line_block, generic_block)
+
+        expect(tester.response[:status]).to eq(200)
+      end
+
+      it 'accepts multiple redirect' do
+        redirect_url = 'http://example.com/redirect'
+        redirect_url_2 = 'http://example.com/redirect_2'
+
+
+        stub_request(:get, url.to_s)
+          .with(headers: headers_with_authorization)
+          .to_return(status: 301, headers: { 'location' => redirect_url })
+        stub_request(:get, redirect_url)
+          .with(headers: headers_without_authorization)
+          .to_return(status: 307, headers: { 'location' => redirect_url_2 })
+        stub_request(:get, redirect_url_2)
           .with(headers: headers_without_authorization)
           .to_return(status: 200)
 

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -562,5 +562,34 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
 
       expect(streamed_chunks).to eq(["multi\n touched", "line\n touched", "response\n touched", "body\n touched"])
     end
+
+
+    context '301 redirect' do
+      let(:headers_with_authorization) {
+        {
+          accept: 'application/fhir+ndjson',
+          authorization: "Bearer #{bearer_token}"
+        }
+      }
+      let(:headers_without_authorization) {
+        {
+          accept: 'application/fhir+ndjson'
+        }
+      }
+      let(:redirect_url) { 'http://example.com/redirect' }
+
+      it 'accepts 301 redirect' do
+        stub_request(:get, url.to_s)
+          .with(headers: headers_with_authorization)
+          .to_return(status: 301, headers: { 'location' => redirect_url })
+        stub_request(:get, redirect_url)
+          .with(headers: headers_without_authorization)
+          .to_return(status: 200)
+
+        tester.stream_ndjson(url, headers_with_authorization, process_line_block, generic_block)
+
+        expect(tester.response[:status]).to eq(200)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes GitHub Issue #60 

The changes allows Bulk Data File download testing accept HTTP Redirect status 301/302/303/307

When requesting redirect endpoint, Bulk Data client does NOT send authorization header.