### PR TITLE
Relax 40X error specificity in Additional Tests

### DIFF
--- a/lib/onc_certification_g10_test_kit/smart_invalid_token_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_invalid_token_group.rb
@@ -158,7 +158,7 @@ module ONCCertificationG10TestKit
 
         post(smart_token_url, body: oauth2_params, name: :token, headers: oauth2_headers)
 
-        assert_response_status(400)
+        assert_response_status([400, 401, 403])
       end
     end
 

--- a/lib/onc_certification_g10_test_kit/token_revocation_group.rb
+++ b/lib/onc_certification_g10_test_kit/token_revocation_group.rb
@@ -126,7 +126,7 @@ module ONCCertificationG10TestKit
 
         post(smart_token_url, body: oauth2_params, headers: oauth2_headers)
 
-        assert_response_status([400, 401])
+        assert_response_status([400, 401, 403])
       end
     end
   end


### PR DESCRIPTION
Inferno's Tab 6: Additional Tests currently features two tests that evaluate very similar functionality.

**6.2.03 Token refresh fails after token revocation** ensures that, when given a refresh token that has been revoked and is no longer valid, the Health IT module does not issue access tokens.

**6.5.03 OAuth token exchange fails when supplied invalid code** ensures that, when given an authorization code that is invalid, the Health IT module does not issue access tokens.

Auth0, one of the most popular authorization and authentication providers, considers both of these `invalid_grant` errors, which yield 403 responses per their [documentation](https://auth0.com/docs/api/authentication#standard-error-responses) on Standard Error Responses.

It's in the best interest of both Inferno and the applications it evaluates to accept industry-standard HTTP responses so as not to force Health IT modules to insert home-rolled shims that intersect and massage auth responses, which have the potential to introduce unnecessary lag, complexity, and in the worst case vulnerabilities.

(In addition to adding 403 to both tests, I chose to keep 401 in the 6.2.03 allow list so as not to introduce breaking changes for modules who may be returning that error code already, and subsequently added 401 to 6.5.03 so that the test criteria would have parity.)

Thanks in advance for your consideration.