### PR TITLE
Reduce operation.name != export to warning on Group operation.

### DIFF
--- a/spec/fixtures/CapabilityStatement.json
+++ b/spec/fixtures/CapabilityStatement.json
@@ -56,13 +56,7 @@
           "type": "Patient",
           "operation": [
             {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-                  "valueCode": "SHOULD"
-                }
-              ],
-              "name": "patient-export",
+              "name": "export",
               "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export"
             }
           ]
@@ -71,44 +65,10 @@
           "type": "Group",
           "operation": [
             {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-                  "valueCode": "SHOULD"
-                }
-              ],
               "name": "export",
               "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export"
             }
           ]
-        },
-        {
-          "type": "OperationDefinition",
-          "profile": {
-            "reference": "http://hl7.org/fhir/Profile/OperationDefinition"
-          },
-          "interaction": [
-            {
-              "code": "read"
-            }
-          ],
-          "searchParam": []
-        }
-      ],
-      "operation": [
-        {
-          "name": "get-resource-counts",
-          "definition": "OperationDefinition/-s-get-resource-counts"
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-              "valueCode": "SHOULD"
-            }
-          ],
-          "name": "export",
-          "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/export"
         }
       ]
     }


### PR DESCRIPTION
See the test description in the PR for an explanation of how this works.  I do not think that we should allow ( 'export' or 'group-export' ) as the name, because 'group-export' does not make sense.  We could just enforce 'export', but it seems like there isn't complete consensus here, particularly since our reference server does not send back 'export' here.  I think the safe thing to do is to just downgrade the name check to a warning (which we avoid in general, but I still am pretty sure that 'export' as the name is the only right thing to do given we are requiring it be mounted there in later tests).

However, we can safely require that some operation is defined on the Group resource, which allows us to still have a failing condition on this test so we don't have to remove it altogether.  So I updated the test to make sure that at least one operation was defined on the Group resource, and you fail if you do not provide some operation there (it just doesn't check the definition field because it may be derived, and it doesn't check the name field because the spec is a little vague).

This update also 'relaxes' the constraint in general from where it was before, which makes me more comfortable than creating a new constraint that didn't exist before.