### PR TITLE
Fix matrix generator so it doesnt break if no description on a test

### DIFF
--- a/lib/onc_certification_g10_test_kit/tasks/generate_matrix.rb
+++ b/lib/onc_certification_g10_test_kit/tasks/generate_matrix.rb
@@ -198,10 +198,10 @@ module ONCCertificationG10TestKit
           ['Inferno Test ID', 22, ->(test) { test.short_id.to_s }],
           ['Inferno Test Name', 65, ->(test) { test.title }],
           ['Inferno Test Description', 65, lambda do |test|
-            natural_indent = test.description.lines
-              .collect { |l| l.index(/[^ ]/) }
-              .select { |l| !l.nil? && l.positive? }.min || 0
-            test.description.lines.map { |l| l[natural_indent..] || "\n" }.join.strip
+            natural_indent = test.description&.lines
+              &.collect { |l| l.index(/[^ ]/) }
+              &.select { |l| !l.nil? && l.positive? }&.min || 0
+            test.description&.lines&.map { |l| l[natural_indent..] || "\n" }&.join&.strip || ''
           end],
           ['Test Procedure Steps', 30, ->(test) { inferno_to_procedure_map[test.short_id].join(', ') }]
         ]
@@ -227,7 +227,7 @@ module ONCCertificationG10TestKit
               this_row.each_with_index do |value, index|
                 inferno_worksheet.add_cell(row, index, value).change_text_wrap(true)
               end
-              inferno_worksheet.change_row_height(row, [26, (test.description.strip.lines.count * 10) + 10].max)
+              inferno_worksheet.change_row_height(row, [26, ((test.description || '').strip.lines.count * 10) + 10].max)
               inferno_worksheet.change_row_vertical_alignment(row, 'top')
               row += 1
             end


### PR DESCRIPTION
Noticed that we didn't have the regenerated matrix in yet, and was going to push it up to the release branch, but found a bug that is fixed here... which led me to morre bugs in us core which are waiting to get pushed through (which is why I didn't include the actual improved xls file in here)