### PR TITLE
Fix Bulk Data conform validates per file

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -178,7 +178,9 @@ module ONCCertificationG10TestKit
       }
 
       stream_ndjson(url, build_headers(requires_access_token), process_line, process_headers)
-      resources_from_all_files.merge!(resources) { |key, all_resources, file_resources| all_resources | file_resources }
+      resources_from_all_files.merge!(resources) do |_key, all_resources, file_resources|
+        all_resources | file_resources
+      end
       line_count
     end
 

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -96,7 +96,12 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       input.merge({ status_output: "[{\"url\":\"#{endpoint}\",\"type\":\"Patient\",\"count\":2}]" })
     end
     let(:patient_input_two_files) do
-      input.merge({ status_output: "[{\"url\":\"#{endpoint}\",\"type\":\"Patient\",\"count\":2},{\"url\":\"#{endpoint}/2\",\"type\":\"Patient\",\"count\":2}]" })
+      input.merge(
+        {
+          status_output: "[{\"url\":\"#{endpoint}\",\"type\":\"Patient\",\"count\":2}," \
+                         "{\"url\":\"#{endpoint}/2\",\"type\":\"Patient\",\"count\":2}]"
+        }
+      )
     end
 
     before do
@@ -328,7 +333,12 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       input.merge({ status_output: "[{\"url\":\"#{endpoint}\",\"type\":\"DiagnosticReport\",\"count\":43}]" })
     end
     let(:diagnostic_input_two_files) do
-      input.merge({ status_output: "[{\"url\":\"#{endpoint}\",\"type\":\"DiagnosticReport\",\"count\":43},{\"url\":\"#{endpoint}/2\",\"type\":\"DiagnosticReport\",\"count\":43}]" })
+      input.merge(
+        {
+          status_output: "[{\"url\":\"#{endpoint}\",\"type\":\"DiagnosticReport\",\"count\":43}," \
+                         "{\"url\":\"#{endpoint}/2\",\"type\":\"DiagnosticReport\",\"count\":43}]"
+        }
+      )
     end
     let(:contents_missing_lab) { String.new }
     let(:contents_missing_note) { String.new }


### PR DESCRIPTION
This PR fixes GitHub Issue #86 

Inferno validate bulk export conformance per file. If server export one resource type into multiple files, which is allowed by Bulk Data Export IG, Inferno validate those separately.

This fix changes conformance validation to per resource type which remove the invalid skip messages.