### PR TITLE
FI-1533: Fix nil safety in additional_patient_ids

### DIFF
--- a/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
@@ -61,11 +61,15 @@ module ONCCertificationG10TestKit
       run do
         smart_app_launch_patient_id = patient_id.presence
         additional_patient_ids_list =
-          additional_patient_ids
-            .split(',')
-            .map(&:strip)
-            .map(&:presence)
-            .compact
+          if additional_patient_ids.present?
+            additional_patient_ids
+              .split(',')
+              .map(&:strip)
+              .map(&:presence)
+              .compact
+          else
+            []
+          end
 
         all_patient_ids = ([smart_app_launch_patient_id] + additional_patient_ids_list).compact.uniq
 

--- a/spec/onc_certification_g10_test_kit/single_patient_api_group_spec.rb
+++ b/spec/onc_certification_g10_test_kit/single_patient_api_group_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe ONCCertificationG10TestKit::SinglePatientAPIGroup do
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(
+        test_session_id: test_session.id,
+        name: name,
+        value: value,
+        type: runnable.config.input_type(name)
+      )
+    end
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+  end
+
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'g10_certification') }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+
+  describe 'setup test' do
+    let(:test) { described_class.tests.first }
+
+    it 'does not raise an error when additional_patient_ids is not provided' do
+      result = run(test, patient_id: '85')
+
+      expect(result.result).to eq('pass')
+    end
+  end
+end

--- a/spec/onc_certification_g10_test_kit/single_patient_api_group_spec.rb
+++ b/spec/onc_certification_g10_test_kit/single_patient_api_group_spec.rb
@@ -24,5 +24,19 @@ RSpec.describe ONCCertificationG10TestKit::SinglePatientAPIGroup do
 
       expect(result.result).to eq('pass')
     end
+
+    it 'outputs the correct patient_ids when additional_patient_ids is not provided' do
+      run(test, patient_id: '85')
+      patient_ids = session_data_repo.load(test_session_id: test_session.id, name: 'patient_ids')
+
+      expect(patient_ids).to eq('85')
+    end
+
+    it 'outputs the correct patient_ids when additional_patient_ids are provided' do
+      run(test, patient_id: '85', additional_patient_ids: '85 , 123,, , 456 ,789')
+      patient_ids = session_data_repo.load(test_session_id: test_session.id, name: 'patient_ids')
+
+      expect(patient_ids).to eq('85,123,456,789')
+    end
   end
 end


### PR DESCRIPTION
#93 describes a nil-safety issue with the `additional_patient_ids` input. This branch makes it nil safe.