### PR TITLE
FI-1501: Fix EHR launch capabilities check

### DIFF
--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -47,7 +47,21 @@ module ONCCertificationG10TestKit
     input_order :url, :ehr_client_id, :ehr_client_secret
 
     group from: :smart_discovery do
-      test from: 'g10_smart_well_known_capabilities'
+      test from: 'g10_smart_well_known_capabilities',
+           config: {
+             options: {
+               required_capabilities: [
+                 'launch-ehr',
+                 'client-confidential-symmetric',
+                 'sso-openid-connect',
+                 'context-banner',
+                 'context-style',
+                 'context-ehr-patient',
+                 'permission-offline',
+                 'permission-user'
+               ]
+             }
+           }
     end
 
     group from: :smart_ehr_launch do

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -49,7 +49,20 @@ module ONCCertificationG10TestKit
     input_order :url, :standalone_client_id, :standalone_client_secret
 
     group from: :smart_discovery do
-      test from: 'g10_smart_well_known_capabilities'
+      test from: 'g10_smart_well_known_capabilities',
+           config: {
+             options: {
+               required_capabilities: [
+                 'launch-standalone',
+                 'client-public',
+                 'client-confidential-symmetric',
+                 'sso-openid-connect',
+                 'context-standalone-patient',
+                 'permission-offline',
+                 'permission-patient'
+               ]
+             }
+           }
     end
 
     group from: :smart_standalone_launch do

--- a/lib/onc_certification_g10_test_kit/well_known_capabilities_test.rb
+++ b/lib/onc_certification_g10_test_kit/well_known_capabilities_test.rb
@@ -19,17 +19,7 @@ module ONCCertificationG10TestKit
       assert capabilities.is_a?(Array),
              "Expected the well-known capabilities to be an Array, but found #{capabilities.class.name}"
 
-      required_smart_capabilities = [
-        'launch-standalone',
-        'client-public',
-        'client-confidential-symmetric',
-        'sso-openid-connect',
-        'context-standalone-patient',
-        'permission-offline',
-        'permission-patient'
-      ]
-
-      missing_capabilities = required_smart_capabilities - capabilities
+      missing_capabilities = (config.options[:required_capabilities] || []) - capabilities
       assert missing_capabilities.empty?,
              "The following capabilities required for this scenario are missing: #{missing_capabilities.join(', ')}"
     end


### PR DESCRIPTION
The check for required SMART capabilities was checking for the standalone patient capabilities in the EHR launch. This branch fixes the EHR launch check to match what was in program.

- Standalone launch capabilities in program: https://github.com/onc-healthit/inferno-program/blob/main/lib/modules/onc_program/onc_standalone_smart_discovery_sequence.rb#L58
- EHR launch capabilities in program: https://github.com/onc-healthit/inferno-program/blob/main/lib/modules/onc_program/onc_smart_discovery_sequence.rb#L53