### PR TITLE
FI-1524 bulk validation

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -194,14 +194,17 @@ module ONCCertificationG10TestKit
       error_count = messages.count { |message| message[:type] == 'error' }
       return if error_count.zero?
 
-      first_error_message = first_error[:resource_id].present? ?
-                      "The id for the first failed resource is #{first_error[:resource_id]}" :
-                      "The line for the first failed resource is #{first_error[:line_number]}"
+      first_error_message = if first_error[:resource_id].present?
+                              "The id for the first failed resource is #{first_error[:resource_id]}"
+                            else
+                              "The line for the first failed resource is #{first_error[:line_number]}"
+                            end
 
       messages.clear
       messages.concat(first_error[:messages])
 
-      assert error_count.zero?, "#{error_count} / #{total} #{resource_type} resources failed profile validation. #{first_error_message}"
+      assert error_count.zero?,
+             "#{error_count} / #{total} #{resource_type} resources failed profile validation. #{first_error_message}"
     end
 
     def perform_bulk_export_validation

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -203,7 +203,8 @@ module ONCCertificationG10TestKit
       messages.concat(first_error[:messages])
 
       assert @invalid_line_count.zero?,
-             "#{@invalid_line_count} / #{total} #{resource_type} resources failed profile validation. #{first_error_message}"
+             "#{@invalid_line_count} / #{total} #{resource_type} resources failed profile validation. " \
+             "#{first_error_message}"
     end
 
     def perform_bulk_export_validation

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -171,9 +171,9 @@ module ONCCertificationG10TestKit
 
         unless resource_is_valid?(resource: resource, profile_url: profile_url)
           if first_error.key?(:line_number)
-            @invalid_line_count += 1
+            @invalid_resource_count += 1
           else
-            @invalid_line_count = 1
+            @invalid_resource_count = 1
             first_error[:line_number] = line_count
             first_error[:messages] = messages.select { |message| ['error', 'warning'].include? message[:type] }
           end
@@ -194,16 +194,16 @@ module ONCCertificationG10TestKit
       line_count
     end
 
-    def process_validation_errors(total)
-      return if @invalid_line_count.zero?
+    def process_validation_errors(resource_count)
+      return if @invalid_resource_count.nil? || @invalid_resource_count.zero?
 
       first_error_message = "The line number for the first failed resource is #{first_error[:line_number]}."
 
       messages.clear
       messages.concat(first_error[:messages])
 
-      assert @invalid_line_count.zero?,
-             "#{@invalid_line_count} / #{total} #{resource_type} resources failed profile validation. " \
+      assert false,
+             "#{@invalid_resource_count} / #{resource_count} #{resource_type} resources failed profile validation. " \
              "#{first_error_message}"
     end
 
@@ -220,19 +220,17 @@ module ONCCertificationG10TestKit
       end
 
       @resources_from_all_files = {}
-      @first_error = {}
-      @invalid_line_count = 0
-      success_count = 0
+      resource_count = 0
 
       file_list.each do |file|
-        success_count += check_file_request(file['url'])
+        resource_count += check_file_request(file['url'])
       end
 
-      process_validation_errors(success_count)
+      process_validation_errors(resource_count)
 
       validate_conformance(resources_from_all_files)
 
-      pass "Successfully validated #{success_count} #{resource_type} resource(s)."
+      pass "Successfully validated #{resource_count} #{resource_type} resource(s)."
     end
   end
 end

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -171,7 +171,6 @@ module ONCCertificationG10TestKit
 
         if !resource_is_valid?(resource: resource, profile_url: profile_url) && !first_error.key?(:line_number)
           first_error[:line_number] = line_count
-          first_error[:resource_id] = resource.id
           first_error[:messages] = messages.select { |message| ['error', 'warning'].include? message[:type] }
         end
       }
@@ -194,11 +193,7 @@ module ONCCertificationG10TestKit
       error_count = messages.count { |message| message[:type] == 'error' }
       return if error_count.zero?
 
-      first_error_message = if first_error[:resource_id].present?
-                              "The id for the first failed resource is #{first_error[:resource_id]}"
-                            else
-                              "The line for the first failed resource is #{first_error[:line_number]}"
-                            end
+      first_error_message = "The line number for the first failed resource is #{first_error[:line_number]}."
 
       messages.clear
       messages.concat(first_error[:messages])

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -175,7 +175,7 @@ module ONCCertificationG10TestKit
           else
             @invalid_resource_count = 1
             first_error[:line_number] = line_count
-            first_error[:messages] = messages.select { |message| ['error', 'warning'].include? message[:type] }
+            first_error[:messages] = messages.dup
           end
         end
       }

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -178,8 +178,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
         .with(headers: { 'Accept' => 'application/fhir+ndjson' })
         .to_return(status: 200, body: contents, headers: headers)
 
-      validation_request = stub_request(:post,
-                            "#{validator_url}/validate?profile=http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")
+      validation_request = stub_request(:post, "#{validator_url}/validate?profile=http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")
         .to_return(status: 200, body: operation_outcome_no_name.to_json)
 
       result = run(runnable, patient_input)

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
   describe '[Patient resources returned conform to US Core Patient Profile] test' do
     let(:runnable) { group.tests[2] }
     let(:resources) { NDJSON::Parser.new('spec/fixtures/Patient.ndjson') }
-    let(:count) {2}
+    let(:count) { 2 }
     let(:patient_input) do
       input.merge({ status_output: "[{\"url\":\"#{endpoint}\",\"type\":\"Patient\",\"count\":#{count}}]" })
     end
@@ -115,10 +115,10 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
             severity: 'error',
             code: 'required',
             details: {
-              text: "Patient.name: minimum required = 1, but only found 0"
+              text: 'Patient.name: minimum required = 1, but only found 0'
             },
             expression: [
-              "Patient"
+              'Patient'
             ]
           }
         ]
@@ -174,7 +174,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
     end
 
     it 'catches all validation errors' do
-      stub_request(:get, "#{endpoint}")
+      stub_request(:get, endpoint.to_s)
         .with(headers: { 'Accept' => 'application/fhir+ndjson' })
         .to_return(status: 200, body: contents, headers: headers)
 
@@ -185,7 +185,9 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
 
       expect(result.result).to eq('fail')
       expect(result.result_message).to start_with('2 / 2 Patient resources failed profile validation')
-      expect(Inferno::Repositories::Messages.new.messages_for_result(result.id).count { |message| message.type == 'error'}).to be(1)
+      expect(Inferno::Repositories::Messages.new.messages_for_result(result.id).count do |message|
+               message.type == 'error'
+             end).to be(1)
     end
   end
 

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -183,12 +183,12 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
 
       result = run(runnable, patient_input)
 
+      messages = Inferno::Repositories::Messages.new.messages_for_result(result.id)
+
       expect(validation_request).to have_been_made.twice
       expect(result.result).to eq('fail')
       expect(result.result_message).to start_with('2 / 2 Patient resources failed profile validation')
-      expect(Inferno::Repositories::Messages.new.messages_for_result(result.id).count do |message|
-               message.type == 'error'
-             end).to be(1)
+      expect(messages.count { |message| message.type == 'error' }).to be(1)
     end
   end
 

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -184,7 +184,8 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       result = run(runnable, patient_input)
 
       expect(result.result).to eq('fail')
-      expect(Inferno::Repositories::Messages.new.messages_for_result(result.id).count { |message| message.type == 'error'}).to be(count)
+      expect(result.result_message).to start_with('2 / 2 Patient resources failed profile validation')
+      expect(Inferno::Repositories::Messages.new.messages_for_result(result.id).count { |message| message.type == 'error'}).to be(1)
     end
   end
 

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       expect(result.result).to eq('pass')
     end
 
-    it 'catches all validation errors' do
+    it 'validates all lines and saves errors for the first failed line' do
       stub_request(:get, endpoint.to_s)
         .with(headers: { 'Accept' => 'application/fhir+ndjson' })
         .to_return(status: 200, body: contents, headers: headers)

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -254,14 +254,14 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
         .with_message('Resource type "Encounter" at line "1" does not match type defined in output "Patient"')
     end
 
-    it 'fails when returned contents is not valid for the expected resource type' do
+    it 'logs messages when returned contents is not valid for the expected resource type' do
       stub_request(:get, url)
         .to_return(status: 200, headers: headers, body: patient_contents)
 
       allow(tester).to receive(:resource_is_valid?).and_return(false)
-      expect { tester.check_file_request(url) }
-        .to raise_exception(Inferno::Exceptions::AssertionException)
-        .with_message('Resource at line "1" does not conform to profile "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient".')
+      tester.check_file_request(url)
+
+      expect(tester.first_error[:line_number]).to eq(1)
     end
 
     context 'with improper headers' do


### PR DESCRIPTION
This PR changes Bulk Data export validation so that

* it validates all lines/resources
* it saves validation errors and warnings from the first failed line/resource
* it returns result message with the count of failed lines/resources

This PR fix Github Issue #104 