### PR TITLE
FI-1546: Dev versioning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    onc_certification_g10_test_kit (2.1.1)
+    onc_certification_g10_test_kit (2.1.1.dev)
       bloomer (~> 1.0.0)
       colorize (~> 0.8.1)
       inferno_core (> 0.2.0)
@@ -264,7 +264,7 @@ GEM
       rubyzip (>= 1.3.0)
     rubyzip (2.3.2)
     sequel (5.42.0)
-    sidekiq (6.4.1)
+    sidekiq (6.4.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ repository.
 
 ## Local Installation Instruction
 
-- Clone this repo.
+- [Download an official
+  release](https://github.com/onc-healthit/onc-certification-g10-test-kit/releases)
 - run `setup.sh`
 - run `run.sh`
 - navigate to `http://localhost`

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -106,15 +106,15 @@ module ONCCertificationG10TestKit
       return [] if VERSION.match?(/\A\d+\.\d+\.\d+\z/)
 
       [{
-         type: 'error',
-         message: <<~MESSAGE
-           This is a development version (`#{VERSION}`) of the ONC Certification
-           (g)(10) Standardized API Test Kit and is not suitable for
-           certification. Please [download an official
-           release](https://github.com/onc-healthit/onc-certification-g10-test-kit/releases)
-           if you did not intend to use the development version.
-         MESSAGE
-       }]
+        type: 'error',
+        message: <<~MESSAGE
+          This is a development version (`#{VERSION}`) of the ONC Certification
+          (g)(10) Standardized API Test Kit and is not suitable for
+          certification. Please [download an official
+          release](https://github.com/onc-healthit/onc-certification-g10-test-kit/releases)
+          if you did not intend to use the development version.
+        MESSAGE
+      }]
     end
   end
 end

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -5,7 +5,7 @@ module ONCCertificationG10TestKit
     EXPECTED_VALIDATOR_VERSION = '2.1.0'.freeze
 
     def configuration_messages
-      validator_version_message + terminology_messages
+      validator_version_message + terminology_messages + version_message
     end
 
     def terminology_checker
@@ -100,6 +100,21 @@ module ONCCertificationG10TestKit
       end
 
       messages
+    end
+
+    def version_message
+      return [] if VERSION.match?(/\A\d+\.\d+\.\d+\z/)
+
+      [{
+         type: 'error',
+         message: <<~MESSAGE
+           This is a development version (`#{VERSION}`) of the ONC Certification
+           (g)(10) Standardized API Test Kit and is not suitable for
+           certification. Please [download an official
+           release](https://github.com/onc-healthit/onc-certification-g10-test-kit/releases)
+           if you did not intend to use the development version.
+         MESSAGE
+       }]
     end
   end
 end

--- a/lib/onc_certification_g10_test_kit/version.rb
+++ b/lib/onc_certification_g10_test_kit/version.rb
@@ -1,3 +1,3 @@
 module ONCCertificationG10TestKit
-  VERSION = '2.1.1'.freeze
+  VERSION = '2.1.1.dev'.freeze
 end


### PR DESCRIPTION
This branch adds a configuration error message when using a development version. When not using an official release, the version will end in `.dev`.