### PR TITLE
FI-1553 Update bulk data omit message to be consistent with v1.9

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -215,7 +215,7 @@ module ONCCertificationG10TestKit
       file_list = JSON.parse(status_output).select { |file| file['type'] == resource_type }
       if file_list.empty?
         message = "No #{resource_type} resource file item returned by server."
-        omit_if (OMIT_KLASS.include? resource_type), message
+        omit_if (OMIT_KLASS.include? resource_type), "#{message} #{resource_type} resources are optional."
         skip message
       end
 

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -586,7 +586,8 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       result = run(runnable, location_input.merge({ status_output: bad_status_output }))
 
       expect(result.result).to eq('omit')
-      expect(result.result_message).to eq('No Location resource file item returned by server.')
+      expect(result.result_message).to eq('No Location resource file item returned by server. ' \
+                                          'Location resources are optional.')
     end
 
     it 'fails when non Location resources are returned' do
@@ -637,7 +638,8 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       result = run(runnable, medication_input.merge({ status_output: bad_status_output }))
 
       expect(result.result).to eq('omit')
-      expect(result.result_message).to eq('No Medication resource file item returned by server.')
+      expect(result.result_message).to eq('No Medication resource file item returned by server. ' \
+                                          'Medication resources are optional.')
     end
 
     it 'fails when the returned resources are not of the expected profile' do


### PR DESCRIPTION
Updates the omit message when no Medication/Location resources are provided in bulk data to explicitely state that they are not required, so user knows that this is not an error (if they do not know what 'omit' means).  This language is used in v1.9 and it makes sense to carry it forward here.

See #111 for screenshots.  This adds '<resourcetype> resources are optional.' to the omit message.