### PR TITLE
FI-1556 Updates links in descriptions to correct version of Bulk IG per regs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ supports all required standards, including:
 * Health Level 7 (HL7®) Fast Healthcare Interoperability Resources (FHIR®) Release 4.0.1
 * FHIR US Core Implementation Guide (IG) STU 3.1.1
 * SMART Application Launch Framework Implementation Guide Release 1.0.0
-* HL7 FHIR Bulk Data Access (Flat FHIR) (v1.0.0: STU 1)
+* HL7 FHIR Bulk Data Access (Flat FHIR) (v1.0.1: STU 1)
 
 This test kit is [open
 source](https://github.com/onc-healthit/onc-certification-g10-test-kit) and

--- a/lib/onc_certification_g10_test_kit/bulk_data_authorization.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_authorization.rb
@@ -6,8 +6,8 @@ module ONCCertificationG10TestKit
     short_description 'Demonstrate SMART Backend Services Authorization for Bulk Data.'
     description <<~DESCRIPTION
       Bulk Data servers are required to authorize clients using the
-      [Backend Service Authorization](http://hl7.org/fhir/uv/bulkdata/STU1/authorization/index.html)
-      specification as defined in the [FHIR Bulk Data Access IG v1.0.0](http://hl7.org/fhir/uv/bulkdata/STU1/).
+      [Backend Service Authorization](http://hl7.org/fhir/uv/bulkdata/STU1.0.1/authorization/index.html)
+      specification as defined in the [FHIR Bulk Data Access IG v1.0.1](http://hl7.org/fhir/uv/bulkdata/STU1.0.1/).
 
       In this set of tests, Inferno serves as a Bulk Data client that requests authorization
       from the Bulk Data authorization server.  It also performs a number of negative tests
@@ -89,7 +89,7 @@ module ONCCertificationG10TestKit
         error response as described in [Section 5.2](https://tools.ietf.org/html/rfc6749#section-5.2).
         ```
       DESCRIPTION
-      # link 'http://hl7.org/fhir/uv/bulkdata/STU1/authorization/index.html#protocol-details'
+      # link 'http://hl7.org/fhir/uv/bulkdata/STU1.0.1/authorization/index.html#protocol-details'
 
       run do
         post_request_content = AuthorizationRequestBuilder.build(encryption_method: bulk_encryption_method,
@@ -120,7 +120,7 @@ module ONCCertificationG10TestKit
         error response as described in [Section 5.2](https://tools.ietf.org/html/rfc6749#section-5.2).
         ```
       DESCRIPTION
-      # link 'http://hl7.org/fhir/uv/bulkdata/STU1/authorization/index.html#protocol-details'
+      # link 'http://hl7.org/fhir/uv/bulkdata/STU1.0.1/authorization/index.html#protocol-details'
 
       run do
         post_request_content = AuthorizationRequestBuilder.build(encryption_method: bulk_encryption_method,
@@ -160,7 +160,7 @@ module ONCCertificationG10TestKit
         error response as described in [Section 5.2](https://tools.ietf.org/html/rfc6749#section-5.2).
         ```
       DESCRIPTION
-      # link 'http://hl7.org/fhir/uv/bulkdata/STU1/authorization/index.html#protocol-details'
+      # link 'http://hl7.org/fhir/uv/bulkdata/STU1.0.1/authorization/index.html#protocol-details'
 
       run do
         post_request_content = AuthorizationRequestBuilder.build(encryption_method: bulk_encryption_method,
@@ -180,7 +180,7 @@ module ONCCertificationG10TestKit
       description <<~DESCRIPTION
         If the access token request is valid and authorized, the authorization server SHALL issue an access token in response.
       DESCRIPTION
-      # link 'http://hl7.org/fhir/uv/bulkdata/STU1/authorization/index.html#issuing-access-tokens'
+      # link 'http://hl7.org/fhir/uv/bulkdata/STU1.0.1/authorization/index.html#issuing-access-tokens'
 
       output :authentication_response
 
@@ -211,7 +211,7 @@ module ONCCertificationG10TestKit
         | expires_in | required | The lifetime in seconds of the access token. The recommended value is 300, for a five-minute token lifetime. |
         | scope | required | Scope of access authorized. Note that this can be different from the scopes requested by the app. |
       DESCRIPTION
-      # link 'http://hl7.org/fhir/uv/bulkdata/STU1/authorization/index.html#issuing-access-tokens'
+      # link 'http://hl7.org/fhir/uv/bulkdata/STU1.0.1/authorization/index.html#issuing-access-tokens'
 
       input :authentication_response
       output :bearer_token

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export.rb
@@ -130,11 +130,11 @@ module ONCCertificationG10TestKit
       description <<~DESCRIPTION
         The FHIR server SHALL limit the data returned to only those FHIR resources for which the client is authorized.
 
-        [FHIR R4 Security](http://build.fhir.org/security.html#AccessDenied) and
+        [FHIR R4 Security](https://www.hl7.org/fhir/security.html#AccessDenied) and
         [The OAuth 2.0 Authorization Framework: Bearer Token Usage](https://tools.ietf.org/html/rfc6750#section-3.1)
         recommend using HTTP status code 401 for invalid token but also allow the actual result be controlled by policy and context.
       DESCRIPTION
-      # link 'http://hl7.org/fhir/uv/bulkdata/STU1/export/index.html#bulk-data-kick-off-request'
+      # link 'http://hl7.org/fhir/uv/bulkdata/STU1.0.1/export/index.html#bulk-data-kick-off-request'
 
       include ExportKickOffPerformer
 
@@ -154,7 +154,7 @@ module ONCCertificationG10TestKit
         * HTTP Status Code of 202 Accepted
         * Content-Location header with the absolute URL of an endpoint for subsequent status requests (polling location)
       DESCRIPTION
-      # link 'http://hl7.org/fhir/uv/bulkdata/STU1/export/index.html#response---success'
+      # link 'http://hl7.org/fhir/uv/bulkdata/STU1.0.1/export/index.html#response---success'
 
       include ExportKickOffPerformer
 
@@ -183,7 +183,7 @@ module ONCCertificationG10TestKit
 
         * transactionTime, request, requiresAccessToken, output, and error
       DESCRIPTION
-      # link 'http://hl7.org/fhir/uv/bulkdata/STU1/export/index.html#bulk-data-status-request'
+      # link 'http://hl7.org/fhir/uv/bulkdata/STU1.0.1/export/index.html#bulk-data-status-request'
 
       input :polling_url
 
@@ -248,7 +248,7 @@ module ONCCertificationG10TestKit
 
         * url - the path to the file. The format of the file SHOULD reflect that requested in the _outputFormat parameter of the initial kick-off request.
       DESCRIPTION
-      # link 'http://hl7.org/fhir/uv/bulkdata/STU1/export/index.html#response---complete-status'
+      # link 'http://hl7.org/fhir/uv/bulkdata/STU1.0.1/export/index.html#response---complete-status'
 
       input :status_response
 
@@ -277,7 +277,7 @@ module ONCCertificationG10TestKit
         After a bulk data request has been started, a client MAY send a delete request to the URL provided in the Content-Location header to cancel the request.
         Bulk Data Server MUST support client's delete request and return HTTP Status Code of "202 Accepted"
       DESCRIPTION
-      # link 'http://hl7.org/fhir/uv/bulkdata/STU1/export/index.html#bulk-data-delete-request'
+      # link 'http://hl7.org/fhir/uv/bulkdata/STU1.0.1/export/index.html#bulk-data-delete-request'
 
       include ExportKickOffPerformer
 

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
@@ -54,12 +54,12 @@ module ONCCertificationG10TestKit
         If the requiresAccessToken field in the Complete Status body is set to true, the request SHALL include a valid#{' '}
         access token.
 
-        [FHIR R4 Security](http://build.fhir.org/security.html#AccessDenied) and
+        [FHIR R4 Security](https://www.hl7.org/fhir/security.html#AccessDenied) and
         [The OAuth 2.0 Authorization Framework: Bearer Token Usage](https://tools.ietf.org/html/rfc6750#section-3.1)
         recommend using HTTP status code 401 for invalid token but also allow the actual result be controlled by policy#{' '}
         and context.
       DESCRIPTION
-      # link 'http://hl7.org/fhir/uv/bulkdata/STU1/export/index.html#file-request'
+      # link 'http://hl7.org/fhir/uv/bulkdata/STU1.0.1/export/index.html#file-request'
 
       input :bulk_download_url
 

--- a/lib/onc_certification_g10_test_kit/multi_patient_api.rb
+++ b/lib/onc_certification_g10_test_kit/multi_patient_api.rb
@@ -21,8 +21,8 @@ module ONCCertificationG10TestKit
     description %(
       Demonstrate the ability to export clinical data for multiple patients in
       a group using [FHIR Bulk Data Access
-      IG](http://hl7.org/fhir/uv/bulkdata/STU1/). This test uses [Backend Services
-      Authorization](http://hl7.org/fhir/uv/bulkdata/STU1/authorization/index.html)
+      IG](http://hl7.org/fhir/uv/bulkdata/STU1.0.1/). This test uses [Backend Services
+      Authorization](http://hl7.org/fhir/uv/bulkdata/STU1.0.1/authorization/index.html)
       to obtain an access token from the server. After authorization, a group
       level bulk data export request is initialized. Finally, this test reads
       exported NDJSON files from the server and validates the resources in


### PR DESCRIPTION
The regulation is technically to v1.0.1 of Bulk Data, which has slightly different links than v1.0.0.  This was raised to ONC via their comment portal.  Technically the changes are very small and do not affect the parts that we linked to generally, but we need to be very precise.

I also found a link to build.fhir.org separately which is incorrect.