### PR TITLE
Update version to .dev

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    onc_certification_g10_test_kit (2.2.2)
+    onc_certification_g10_test_kit (2.2.2.dev)
       bloomer (~> 1.0.0)
       colorize (~> 0.8.1)
       inferno_core (> 0.2.0)

--- a/lib/onc_certification_g10_test_kit/version.rb
+++ b/lib/onc_certification_g10_test_kit/version.rb
@@ -1,3 +1,3 @@
 module ONCCertificationG10TestKit
-  VERSION = '2.2.2'.freeze
+  VERSION = '2.2.2.dev'.freeze
 end


### PR DESCRIPTION
We do this after every release to ensure that nobody is running an upgraded version from `main` that is functionally different than the version number indicates (unless they want to -- they can ignore the error).