### PR TITLE
FI-1639 Update limited app launch to have launch use same inputs as in Standalone App Launch test

### DIFF
--- a/config/presets/inferno_reference_server_preset.json
+++ b/config/presets/inferno_reference_server_preset.json
@@ -74,13 +74,6 @@
       "value": null
     },
     {
-      "name": "limited_requested_scopes",
-      "type": "textarea",
-      "title": "Standalone Scope",
-      "description": "OAuth 2.0 scope provided by system to enable all required functionality",
-      "value": "launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/Procedure.read patient/Provenance.read patient/PractitionerRole.read"
-    },
-    {
       "name": "ehr_client_id",
       "type": "text",
       "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"

--- a/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
@@ -8,11 +8,14 @@ module ONCCertificationG10TestKit
     short_title 'Limited Access App'
 
     input_instructions %(
-      The purpose of this test is to demonstrate that users can restrict access
-      granted to apps to a limited number of resources. Enter which resources the
-      user will grant access to below, and during the launch process only grant
-      access to those resources. Inferno will verify that access granted matches
-      these expectations.
+      The purpose of this test is to demonstrate that app users can restrict
+      access granted to apps to a limited number of resources. Enter which
+      resources the user will grant access to below, and during the launch
+      process only grant access to those resources. Inferno will verify that
+      access granted matches these expectations.
+
+      All other inputs are locked to ensure the same app configuration as in the
+      Standalone Patient App - Full Access test.
     )
 
     description %(
@@ -76,7 +79,7 @@ module ONCCertificationG10TestKit
       config(
         inputs: {
           client_id: { locked: true },
-          client_secret: { locked: true },
+          client_secret: { locked: true, optional: false },
           url: { locked: true },
           requested_scopes: { locked: true },
           use_pkce: { locked: true },

--- a/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
@@ -20,7 +20,10 @@ module ONCCertificationG10TestKit
       Launch to a [SMART on FHIR](http://hl7.org/fhir/smart-app-launch/1.0.0/)
       confidential client with limited access granted to the app based on user
       input. The tester is expected to grant the application access to a subset
-      of desired resource types.
+      of desired resource types.  The launch is performed using the same app
+      configuration as in the Standalone Patient App test, demonstrating that
+      the user is control over what scopes are granted to the app as required in
+      the (g)(10) Standardized API criterion.
     )
     id :g10_smart_limited_app
     run_as_group
@@ -45,16 +48,25 @@ module ONCCertificationG10TestKit
         allows an app, like Inferno, to be launched independent of an
         existing EHR session. It is one of the two launch methods described in
         the SMART App Launch Framework alongside EHR Launch. The app will
-        request authorization for the provided scope from the authorization
-        endpoint, ultimately receiving an authorization token which can be used
-        to gain access to resources on the FHIR server.
+        request authorization for the provided scope(s) from the authorization
+        endpoint, and the user of the app will choose to either grant
+        the app access to the requested scope(s), or to deny one or all of the requested
+        scope(s).
+
+        This test verifies the ability of a server to provide a user
+        with the choice of which scopes to grant an app.  Allowing users to choose
+        which resource types to grant access to is a requirement of the ONC
+        (g)(10) certification criteria.  Prior to the test, the tester specifies
+        which resource types will be granted, and then during the authorization
+        process the tester grants access to those scopes.
 
         # Test Methodology
 
-        Inferno will redirect the user to the the authorization endpoint so that
+        Inferno will redirect the user to the authorization endpoint so that
         they may provide any required credentials and authorize the application.
         Upon successful authorization, Inferno will exchange the authorization
-        code provided for an access token.
+        code provided for an access token. Inferno verifies that the server only
+        grants access to the resources specified by the user.
 
         For more information on the #{title}:
 
@@ -67,14 +79,13 @@ module ONCCertificationG10TestKit
           client_id: { locked: true },
           client_secret: { locked: true },
           url: { locked: true },
+          requested_scopes: { locked: true },
+          use_pkce: { locked: true },
+          pkce_code_challenge_method: { locked: true },
           code: { name: :limited_code },
           state: { name: :limited_state },
           patient_id: { name: :limited_patient_id },
           access_token: { name: :limited_access_token },
-          requested_scopes: {
-            name: :limited_requested_scopes,
-            title: 'Limited Access Scope'
-          },
           # TODO: separate standalone/ehr discovery outputs
           smart_authorization_url: { locked: true, title: 'SMART Authorization Url' },
           smart_token_url: { locked: true, title: 'SMART Token Url' },

--- a/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
@@ -29,7 +29,6 @@ module ONCCertificationG10TestKit
     run_as_group
 
     input_order :expected_resources,
-                :limited_requested_scopes,
                 :use_pkce,
                 :pkce_code_challenge_method,
                 :url,
@@ -152,7 +151,6 @@ module ONCCertificationG10TestKit
       test from: :g10_limited_scope_grant do
         config(
           inputs: {
-            requested_scopes: { name: :limited_requested_scopes },
             received_scopes: { name: :limited_received_scopes }
           }
         )
@@ -163,7 +161,6 @@ module ONCCertificationG10TestKit
           config: {
             inputs: {
               patient_id: { name: :limited_patient_id },
-              requested_scopes: { name: :limited_requested_scopes },
               received_scopes: { name: :limited_received_scopes },
               smart_credentials: { name: :limited_smart_credentials }
             }


### PR DESCRIPTION
**Note for release notes: this removes an input so presets should be updated.  A non-fatal warning will be issued in the console otherwise.**

This updates the input to the Limited App Launch test to use the same inputs as in the Standalone App Launch test because the purpose of the test to ensure that the user has control over which scopes are granted, and that an app doesn't have to request different scopes (which the user likely will not have control over).  This makes this test consistent with the behavior in <v1.9, as it was inadvertently changed.

To test, verify that the limited launch still works properly, and that whatever scopes and pkce-related fields that are used in the Standalone App Launch test are persisted in this input.  Also, the pkce-related fields will now be locked.

<img width="594" alt="Screen Shot 2022-07-27 at 12 29 05 PM" src="https://user-images.githubusercontent.com/412901/181300342-ab271eaf-94a9-444a-bd59-b49fb1ba22b8.png">

See #170 


