### PR TITLE
FI-1649: Update terminology build for US Core 4

### DIFF
--- a/lib/inferno/terminology/expected_manifest.yml
+++ b/lib/inferno/terminology/expected_manifest.yml
@@ -674,6 +674,17 @@
   :type: bloom
   :code_systems:
   - http://hl7.org/fhir/narrative-status
+- :url: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1099.30
+  :file: cts_nlm_nih_gov_fhir_ValueSet_2_16_840_1_113762_1_4_1099_30.msgpack
+  :count: 124
+  :type: bloom
+  :code_systems: []
+- :url: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.6
+  :file: cts_nlm_nih_gov_fhir_ValueSet_2_16_840_1_113762_1_4_1010_6.msgpack
+  :count: 172
+  :type: bloom
+  :code_systems:
+  - http://hl7.org/fhir/sid/cvx
 - :url: http://hl7.org/fhir/ValueSet/medicationrequest-category
   :file: hl7_org_fhir_ValueSet_medicationrequest-category.msgpack
   :count: 4
@@ -686,6 +697,18 @@
   :type: bloom
   :code_systems:
   - http://loinc.org
+- :url: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.11.20.9.38
+  :file: cts_nlm_nih_gov_fhir_ValueSet_2_16_840_1_113883_11_20_9_38.msgpack
+  :count: 8
+  :type: bloom
+  :code_systems:
+  - http://snomed.info/sct
+- :url: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.1066
+  :file: cts_nlm_nih_gov_fhir_ValueSet_2_16_840_1_114222_4_11_1066.msgpack
+  :count: 852
+  :type: bloom
+  :code_systems:
+  - urn:oid:2.16.840.1.113883.6.101
 - :url: http://hl7.org/fhir/ValueSet/resource-types
   :file: hl7_org_fhir_ValueSet_resource-types.msgpack
   :count: 148
@@ -1152,3 +1175,8 @@
   :count: 4
   :type: bloom
   :code_systems: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+- :url: urn:oid:2.16.840.1.113883.6.101
+  :file: urn_oid_2_16_840_1_113883_6_101.msgpack
+  :count: 970
+  :type: bloom
+  :code_systems: urn:oid:2.16.840.1.113883.6.101

--- a/lib/inferno/terminology/expected_manifest.yml
+++ b/lib/inferno/terminology/expected_manifest.yml
@@ -628,6 +628,8 @@
   - http://www.cms.gov/Medicare/Coding/ICD10
   - http://ada.org/cdt
   - http://loinc.org
+  - urn:oid:2.16.840.1.113883.6.285
+  - urn:oid:2.16.840.1.113883.6.13
 - :url: http://hl7.org/fhir/ValueSet/device-action
   :file: hl7_org_fhir_ValueSet_device-action.msgpack
   :count: 622
@@ -1140,6 +1142,16 @@
   :count: 867
   :type: bloom
   :code_systems: http://ada.org/cdt
+- :url: urn:oid:2.16.840.1.113883.6.285
+  :file: urn_oid_2_16_840_1_113883_6_285.msgpack
+  :count: 7783
+  :type: bloom
+  :code_systems: urn:oid:2.16.840.1.113883.6.285
+- :url: urn:oid:2.16.840.1.113883.6.13
+  :file: urn_oid_2_16_840_1_113883_6_13.msgpack
+  :count: 867
+  :type: bloom
+  :code_systems: urn:oid:2.16.840.1.113883.6.13
 - :url: http://terminology.hl7.org/CodeSystem/v3-ActReason
   :file: terminology_hl7_org_CodeSystem_v3-ActReason.msgpack
   :count: 280

--- a/lib/inferno/terminology/expected_manifest.yml
+++ b/lib/inferno/terminology/expected_manifest.yml
@@ -111,11 +111,12 @@
   - http://terminology.hl7.org/CodeSystem/condition-ver-status
 - :url: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category
   :file: hl7_org_fhir_us_core_ValueSet_us-core-condition-category.msgpack
-  :count: 3
+  :count: 4
   :type: bloom
   :code_systems:
   - http://terminology.hl7.org/CodeSystem/condition-category
   - http://hl7.org/fhir/us/core/CodeSystem/condition-category
+  - http://snomed.info/sct
 - :url: http://hl7.org/fhir/ValueSet/condition-severity
   :file: hl7_org_fhir_ValueSet_condition-severity.msgpack
   :count: 3
@@ -124,7 +125,7 @@
   - http://snomed.info/sct
 - :url: http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code
   :file: hl7_org_fhir_us_core_ValueSet_us-core-condition-code.msgpack
-  :count: 297182
+  :count: 297482
   :type: bloom
   :code_systems:
   - http://snomed.info/sct
@@ -381,7 +382,7 @@
   - http://hl7.org/fhir/address-type
 - :url: http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state
   :file: hl7_org_fhir_us_core_ValueSet_us-core-usps-state.msgpack
-  :count: 59
+  :count: 62
   :type: bloom
   :code_systems:
   - https://www.usps.com/
@@ -556,7 +557,7 @@
   - http://terminology.hl7.org/CodeSystem/v2-0131
 - :url: http://hl7.org/fhir/us/core/ValueSet/simple-language
   :file: hl7_org_fhir_us_core_ValueSet_simple-language.msgpack
-  :count: 8212
+  :count: 8239
   :type: bloom
   :code_systems:
   - urn:ietf:bcp:47
@@ -600,7 +601,7 @@
   - http://terminology.hl7.org/CodeSystem/v3-NullFlavor
 - :url: http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role
   :file: hl7_org_fhir_us_core_ValueSet_us-core-provider-role.msgpack
-  :count: 237
+  :count: 862
   :type: bloom
   :code_systems:
   - http://nucc.org/provider-taxonomy
@@ -618,14 +619,15 @@
   - http://hl7.org/fhir/event-status
 - :url: http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code
   :file: hl7_org_fhir_us_core_ValueSet_us-core-procedure-code.msgpack
-  :count: 285523
+  :count: 556515
   :type: bloom
   :code_systems:
   - http://www.ama-assn.org/go/cpt
   - http://snomed.info/sct
-  - urn:oid:2.16.840.1.113883.6.285
+  - http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets
   - http://www.cms.gov/Medicare/Coding/ICD10
-  - urn:oid:2.16.840.1.113883.6.13
+  - http://ada.org/cdt
+  - http://loinc.org
 - :url: http://hl7.org/fhir/ValueSet/device-action
   :file: hl7_org_fhir_ValueSet_device-action.msgpack
   :count: 622
@@ -666,9 +668,33 @@
   :type: bloom
   :code_systems:
   - http://hl7.org/fhir/provenance-entity-role
+- :url: http://hl7.org/fhir/ValueSet/narrative-status
+  :file: hl7_org_fhir_ValueSet_narrative-status.msgpack
+  :count: 4
+  :type: bloom
+  :code_systems:
+  - http://hl7.org/fhir/narrative-status
+- :url: http://hl7.org/fhir/ValueSet/medicationrequest-category
+  :file: hl7_org_fhir_ValueSet_medicationrequest-category.msgpack
+  :count: 4
+  :type: bloom
+  :code_systems:
+  - http://terminology.hl7.org/CodeSystem/medicationrequest-category
+- :url: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
+  :file: hl7_org_fhir_us_core_ValueSet_us-core-vital-signs.msgpack
+  :count: 19
+  :type: bloom
+  :code_systems:
+  - http://loinc.org
+- :url: http://hl7.org/fhir/ValueSet/resource-types
+  :file: hl7_org_fhir_ValueSet_resource-types.msgpack
+  :count: 148
+  :type: bloom
+  :code_systems:
+  - http://hl7.org/fhir/resource-types
 - :url: urn:ietf:bcp:47
   :file: urn_ietf_bcp_47.msgpack
-  :count: 8533
+  :count: 8561
   :type: bloom
   :code_systems: urn:ietf:bcp:47
 - :url: http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical
@@ -963,7 +989,7 @@
   :code_systems: http://hl7.org/fhir/address-type
 - :url: https://www.usps.com/
   :file: www_usps_com_.msgpack
-  :count: 59
+  :count: 62
   :type: bloom
   :code_systems: https://www.usps.com/
 - :url: http://hl7.org/fhir/days-of-week
@@ -1076,21 +1102,21 @@
   :count: 3
   :type: bloom
   :code_systems: http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender
-- :url: urn:oid:2.16.840.1.113883.6.285
-  :file: urn_oid_2_16_840_1_113883_6_285.msgpack
+- :url: http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets
+  :file: www_cms_gov_Medicare_Coding_HCPCSReleaseCodeSets.msgpack
   :count: 7783
   :type: bloom
-  :code_systems: urn:oid:2.16.840.1.113883.6.285
+  :code_systems: http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets
 - :url: http://www.cms.gov/Medicare/Coding/ICD10
   :file: www_cms_gov_Medicare_Coding_ICD10.msgpack
   :count: 190673
   :type: bloom
   :code_systems: http://www.cms.gov/Medicare/Coding/ICD10
-- :url: urn:oid:2.16.840.1.113883.6.13
-  :file: urn_oid_2_16_840_1_113883_6_13.msgpack
+- :url: http://ada.org/cdt
+  :file: ada_org_cdt.msgpack
   :count: 867
   :type: bloom
-  :code_systems: urn:oid:2.16.840.1.113883.6.13
+  :code_systems: http://ada.org/cdt
 - :url: http://terminology.hl7.org/CodeSystem/v3-ActReason
   :file: terminology_hl7_org_CodeSystem_v3-ActReason.msgpack
   :count: 280
@@ -1121,3 +1147,8 @@
   :count: 5
   :type: bloom
   :code_systems: http://hl7.org/fhir/provenance-entity-role
+- :url: http://terminology.hl7.org/CodeSystem/medicationrequest-category
+  :file: terminology_hl7_org_CodeSystem_medicationrequest-category.msgpack
+  :count: 4
+  :type: bloom
+  :code_systems: http://terminology.hl7.org/CodeSystem/medicationrequest-category

--- a/lib/inferno/terminology/fhir_package_manager.rb
+++ b/lib/inferno/terminology/fhir_package_manager.rb
@@ -10,6 +10,19 @@ module Inferno
     module FHIRPackageManager
       class << self
         REGISTRY_SERVER_URL = 'https://packages.fhir.org'.freeze
+        REQUIRED_VSAC_VALUE_SET_URLS = [
+          'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1186.8',
+          'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1099.30',
+          'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.6',
+          'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4',
+          'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.11.20.9.38',
+          'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.1066',
+          'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.1.11.10267',
+          'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1099.27',
+          'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.88.12.80.17',
+          'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.5'
+        ].freeze
+
         # Get the FHIR Package from the registry.
         #
         # e.g. get_package('hl7.fhir.us.core#3.1.1')
@@ -48,6 +61,8 @@ module Inferno
 
             resource = JSON.parse(entry.read) if file_name.end_with? '.json'
             next unless resource&.[]('url')
+
+            next if package.start_with?('us.nlm.vsac') && !REQUIRED_VSAC_VALUE_SET_URLS.include?(resource['url'])
 
             encoded_name = "#{encode_name(resource['url'])}.json"
             encoded_file_name = File.join(path, encoded_name)

--- a/lib/inferno/terminology/loader.rb
+++ b/lib/inferno/terminology/loader.rb
@@ -49,6 +49,11 @@ module Inferno
           end
         end
 
+        def add_alternative_code_system_names(code_systems)
+          code_systems << 'urn:oid:2.16.840.1.113883.6.285' if code_systems.include? 'http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets'
+          code_systems << 'urn:oid:2.16.840.1.113883.6.13' if code_systems.include? 'http://ada.org/cdt'
+        end
+
         # Creates the valueset validators, based on the passed in parameters and
         # the value_sets_repo
         #
@@ -86,13 +91,15 @@ module Inferno
             begin
               # Save the validator to file, and get the "new" count of number of codes
               new_count = save_to_file(vs.value_set, filename, type)
+              code_systems = vs.included_code_systems
 
+              add_alternative_code_system_names(code_systems)
               {
                 url: vs_url,
                 file: name_by_type(File.basename(filename), type),
                 count: new_count,
                 type: type.to_s,
-                code_systems: vs.included_code_systems
+                code_systems: code_systems
               }
             rescue UnknownCodeSystemException,
                    FilterOperationException,

--- a/lib/inferno/terminology/tasks/create_value_set_validators.rb
+++ b/lib/inferno/terminology/tasks/create_value_set_validators.rb
@@ -17,7 +17,7 @@ module Inferno
 
         def run
           Loader.register_umls_db db_for_version
-          Loader.load_value_sets_from_directory(Inferno::Terminology::PACKAGE_DIR, true)
+          Loader.load_value_sets_from_directory(PACKAGE_DIR, true)
           Loader.create_validators(
             type: type,
             minimum_binding_strength: minimum_binding_strength,

--- a/lib/inferno/terminology/tasks/download_fhir_terminology.rb
+++ b/lib/inferno/terminology/tasks/download_fhir_terminology.rb
@@ -17,7 +17,8 @@ module Inferno
         def download_us_core
           FHIRPackageManager.get_package('hl7.fhir.us.core#3.1.1', PACKAGE_DIR, ['ValueSet', 'CodeSystem'])
           FHIRPackageManager.get_package('hl7.fhir.us.core#4.0.0', PACKAGE_DIR, ['ValueSet', 'CodeSystem'])
-          FHIRPackageManager.get_package('us.nlm.vsac#0.3.0', File.join(PACKAGE_DIR, 'vsac'), ['ValueSet', 'CodeSystem'])
+          FHIRPackageManager
+            .get_package('us.nlm.vsac#0.3.0', File.join(PACKAGE_DIR, 'vsac'), ['ValueSet', 'CodeSystem'])
         end
 
         def download_fhir_expansions

--- a/lib/inferno/terminology/tasks/download_fhir_terminology.rb
+++ b/lib/inferno/terminology/tasks/download_fhir_terminology.rb
@@ -16,6 +16,7 @@ module Inferno
 
         def download_us_core
           FHIRPackageManager.get_package('hl7.fhir.us.core#3.1.1', PACKAGE_DIR, ['ValueSet', 'CodeSystem'])
+          FHIRPackageManager.get_package('hl7.fhir.us.core#4.0.0', PACKAGE_DIR, ['ValueSet', 'CodeSystem'])
         end
 
         def download_fhir_expansions

--- a/lib/inferno/terminology/tasks/download_fhir_terminology.rb
+++ b/lib/inferno/terminology/tasks/download_fhir_terminology.rb
@@ -17,6 +17,7 @@ module Inferno
         def download_us_core
           FHIRPackageManager.get_package('hl7.fhir.us.core#3.1.1', PACKAGE_DIR, ['ValueSet', 'CodeSystem'])
           FHIRPackageManager.get_package('hl7.fhir.us.core#4.0.0', PACKAGE_DIR, ['ValueSet', 'CodeSystem'])
+          FHIRPackageManager.get_package('us.nlm.vsac#0.3.0', File.join(PACKAGE_DIR, 'vsac'), ['ValueSet', 'CodeSystem'])
         end
 
         def download_fhir_expansions

--- a/lib/inferno/terminology/value_set.rb
+++ b/lib/inferno/terminology/value_set.rb
@@ -338,9 +338,9 @@ module Inferno
 
         unless vscs.valueSet.empty?
           # If no concepts or filtered systems were present and already created the intersection_set
-          im_val_set = import_value_set(vscs.valueSet.first)
+          im_val_set = import_value_set(vscs.valueSet.first).value_set
           vscs.valueSet.drop(1).each do |im_val|
-            im_val_set = im_val_set.intersection(im_val)
+            im_val_set = im_val_set.intersection(import_value_set(im_val).value_set)
           end
           intersection_set = intersection_set.nil? ? im_val_set : intersection_set.intersection(im_val_set)
         end

--- a/lib/inferno/terminology/value_set.rb
+++ b/lib/inferno/terminology/value_set.rb
@@ -100,7 +100,7 @@ module Inferno
         'http://ihe.net/fhir/ValueSet/IHE.FormatCode.codesystem' =>
           -> { value_sets_repo.find('http://hl7.org/fhir/ValueSet/formatcodes').value_set },
         'https://www.usps.com/' =>
-          -> do
+          lambda do
             codes = [
               'AL', 'AK', 'AS', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', 'FM',
               'FL', 'GA', 'GU', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA',

--- a/lib/inferno/terminology/value_set.rb
+++ b/lib/inferno/terminology/value_set.rb
@@ -88,7 +88,19 @@ module Inferno
         'http://ihe.net/fhir/ValueSet/IHE.FormatCode.codesystem' =>
           -> { value_sets_repo.find('http://hl7.org/fhir/ValueSet/formatcodes').value_set },
         'https://www.usps.com/' =>
-          -> { value_sets_repo.find('http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state').value_set }
+          -> do
+            codes = [
+              'AL', 'AK', 'AS', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', 'FM',
+              'FL', 'GA', 'GU', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA',
+              'ME', 'MH', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV',
+              'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'MP', 'OH', 'OK', 'OR', 'PW',
+              'PA', 'PR', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VI', 'VA',
+              'WA', 'WV', 'WI', 'WY', 'AE', 'AP', 'AA'
+            ]
+            codes.each_with_object(Set.new) do |code, set|
+              set.add(system: 'https://www.usps.com/', code: code)
+            end
+          end
       }.freeze
 
       # https://www.nlm.nih.gov/research/umls/knowledge_sources/metathesaurus/release/attribute_names.html

--- a/lib/inferno/terminology/value_set.rb
+++ b/lib/inferno/terminology/value_set.rb
@@ -72,6 +72,10 @@ module Inferno
           abbreviation: 'CPT',
           name: 'Current Procedural Terminology (CPT)'
         }.freeze,
+        'http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets' => {
+          abbreviation: 'HCPCS',
+          name: 'Healthcare Common Procedure Coding System (HCPCS)'
+        }.freeze,
         'urn:oid:2.16.840.1.113883.6.285' => {
           abbreviation: 'HCPCS',
           name: 'Healthcare Common Procedure Coding System (HCPCS)'
@@ -79,7 +83,11 @@ module Inferno
         'urn:oid:2.16.840.1.113883.6.13' => {
           abbreviation: 'CDT',
           name: 'Code on Dental Procedures and Nomenclature (CDT)'
-        }.freeze
+        }.freeze,
+        'http://ada.org/cdt' => {
+          abbreviation: 'CDT',
+          name: 'Code on Dental Procedures and Nomenclature (CDT)'
+        }
       }.freeze
 
       CODE_SYS = {

--- a/lib/inferno/terminology/value_set.rb
+++ b/lib/inferno/terminology/value_set.rb
@@ -64,6 +64,10 @@ module Inferno
           abbreviation: 'NCI_UCUM',
           name: 'Unified Code for Units of Measure (UCUM)'
         }.freeze,
+        'urn:oid:2.16.840.1.113883.6.101' => {
+          abbreviation: 'NUCCHCPT',
+          name: 'National Uniform Claim Committee - Health Care Provider Taxonomy (NUCCHCPT)'
+        },
         'http://nucc.org/provider-taxonomy' => {
           abbreviation: 'NUCCHCPT',
           name: 'National Uniform Claim Committee - Health Care Provider Taxonomy (NUCCHCPT)'
@@ -124,7 +128,9 @@ module Inferno
       end
 
       def umls_abbreviation(system)
-        return SAB.dig(system, :abbreviation) if system != 'http://nucc.org/provider-taxonomy'
+        if system != 'http://nucc.org/provider-taxonomy' && system != 'urn:oid:2.16.840.1.113883.6.101'
+          return SAB.dig(system, :abbreviation)
+        end
 
         @nucc_system ||= # rubocop:disable Naming/MemoizedInstanceVariableName
           if @db.execute("SELECT COUNT(*) FROM mrconso WHERE SAB = 'NUCCPT'").flatten.first.positive?

--- a/resources/value_sets.yml
+++ b/resources/value_sets.yml
@@ -389,7 +389,7 @@
   :path: target.measure
 - :type: Quantity
   :strength: example
-  :system:
+  :system: 
   :path: target.detail
 - :type: CodeableConcept
   :strength: example
@@ -1661,3 +1661,59 @@
   :strength: required
   :system: http://hl7.org/fhir/ValueSet/provenance-entity-role
   :path: entity.role
+- :type: CodeableConcept
+  :strength: extensible
+  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1186.8
+  :path: code
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/narrative-status
+  :path: text.status
+- :type: CodeableConcept
+  :strength: extensible
+  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1099.30
+  :path: participant.role
+- :type: CodeableConcept
+  :strength: extensible
+  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.6
+  :path: vaccineCode
+- :type: CodeableConcept
+  :strength: extensible
+  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4
+  :path: code
+- :type: CodeableConcept
+  :strength: preferred
+  :system: http://hl7.org/fhir/ValueSet/medicationrequest-category
+  :path: category
+- :type: CodeableConcept
+  :strength: extensible
+  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4
+  :path: medication
+- :type: CodeableConcept
+  :strength: extensible
+  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
+  :path: code
+- :type: Quantity
+  :strength: extensible
+  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
+  :path: value
+- :type: CodeableConcept
+  :strength: extensible
+  :system: http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs
+  :path: component.code
+- :type: Quantity
+  :strength: extensible
+  :system: http://hl7.org/fhir/ValueSet/ucum-vitals-common
+  :path: component.value
+- :type: CodeableConcept
+  :strength: preferred
+  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.11.20.9.38
+  :path: value
+- :type: CodeableConcept
+  :strength: extensible
+  :system: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.1066
+  :path: specialty
+- :type: uri
+  :strength: extensible
+  :system: http://hl7.org/fhir/ValueSet/resource-types
+  :path: target.type


### PR DESCRIPTION
This branch updates the terminology build to include US Core 4.0.0 terminology. The main changes involve adding US Core 4 and VSAC (since it's used by US Core 4) to the list of FHIR packages which will be downloaded, and adding some special handling to avoid processing every VS in VSAC.