### PR TITLE
Fix hard coded resource type in resource access test

### DIFF
--- a/lib/onc_certification_g10_test_kit/resource_access_test.rb
+++ b/lib/onc_certification_g10_test_kit/resource_access_test.rb
@@ -80,7 +80,7 @@ module ONCCertificationG10TestKit
             assert false, error_message
           end
           fhir_search(
-            :allergy_intolerance,
+            resource_type,
             params: search_params.merge(status_search_params)
           )
         end


### PR DESCRIPTION
Resource type was incorrectly hard coded for searches requiring status.