### PR TITLE
Add README reference to PostgreSQL installation for multi-user installs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ repository.
 - run `run.sh`
 - navigate to `http://localhost`
 
+### Multi-user Installations
+
+The default configuration of this test kit uses SQLite for data persistence and
+is optimized for running on a local machine with a single user.  For
+installations on shared servers that may have multiple tests running
+simultaniously, please [configure the installation to use
+PostgreSQL](https://inferno-framework.github.io/inferno-core/deployment/database.html#postgresql)
+to ensure stability in this type of environment.
+
 ### Terminology Support
 #### Terminology prerequisites
 


### PR DESCRIPTION
While we document how to run Inferno in a multi-user environment via the Inferno Framework documentation, this is pretty hidden for the average 'test kit' user, but is important for those running this on a shared server.  I've added a section on this in the README to provide more visibility to this option in the (g)(10) test kit.

An example where this visibiilty would have helped:

https://chat.fhir.org/#narrow/stream/179309-inferno/topic/Inferno.20Local.20Install.20.2E.2E.2E.20issues.20in.20tests.20completing.3F