### PR TITLE
Remove standards version from test titles and fix typo.

### DIFF
--- a/lib/onc_certification_g10_test_kit/multi_patient_api_stu1.rb
+++ b/lib/onc_certification_g10_test_kit/multi_patient_api_stu1.rb
@@ -4,8 +4,8 @@ require_relative 'bulk_data_group_export_validation'
 
 module ONCCertificationG10TestKit
   class MultiPatientAPIGroupSTU1 < Inferno::TestGroup
-    title 'Multi-Patient Authorization and API STU1'
-    short_title 'Multi-Patient API STU1'
+    title 'Multi-Patient Authorization and API'
+    short_title 'Multi-Patient API'
 
     input_instructions %(
       Register Inferno as a bulk data client with the following information, and

--- a/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
@@ -1,7 +1,7 @@
 module ONCCertificationG10TestKit
   class SinglePatientAPIGroup < Inferno::TestGroup
     id :g10_single_patient_api
-    title 'Single Patient API (US Core 3.1.1)'
+    title 'Single Patient API'
     description %(
       For each of the relevant USCDI data elements provided in the
       CapabilityStatement, this test executes the [required supported

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -34,7 +34,7 @@ module ONCCertificationG10TestKit
       Connect is decoded and validated.
 
       For EHRs that use Internet Explorer 11 to display embedded apps,
-      please review [instructions on how to complete the EHR Pracitioner App
+      please review [instructions on how to complete the EHR Practitioner App
       test](https://github.com/onc-healthit/onc-certification-g10-test-kit/wiki/Completing-EHR-Practitioner-App-test-in-Internet-Explorer/).
 
     )


### PR DESCRIPTION
For this release, I think it is better to not have the standards version numbers in the test titles.  Part of the issue is that while convenient for us to verify that the right code is being loaded, it isn't quite 100% accurate because many of our tests actually cut across multiple standards.  Also, for this release, since most users won't use the SVAP versions of standards (requires downloading and changing feature flags), displaying version numbers is premature.

![Screen Shot 2022-08-05 at 1 29 27 PM](https://user-images.githubusercontent.com/412901/183145634-aee5d24c-2ac3-4e07-af84-958db06d8790.png)

This update just changes tests 4 and 5 to not state (US Core v3.1.1 and STU1), and fixes a small typo in another test description.