### PR TITLE
Remove STU1 label from Group Export test for now.

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_stu1.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_stu1.rb
@@ -2,7 +2,7 @@ require_relative 'export_kick_off_performer'
 
 module ONCCertificationG10TestKit
   class BulkDataGroupExportSTU1 < Inferno::TestGroup
-    title 'Group Compartment Export Tests STU1'
+    title 'Group Compartment Export Tests'
     short_description 'Verify that the system supports Group compartment export.'
     description <<~DESCRIPTION
       Verify that system level export on the Bulk Data server follow the Bulk Data Access Implementation Guide


### PR DESCRIPTION
I do not want to change test names until the next release -- this was one that was missed:
```
    5.2 Group Compartment Export Tests STU1
```