### PR TITLE
Update to .dev verison.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    onc_certification_g10_test_kit (2.3.0)
+    onc_certification_g10_test_kit (2.3.0.dev)
       bloomer (~> 1.0.0)
       colorize (~> 0.8.1)
       inferno_core (>= 0.3.7)

--- a/lib/onc_certification_g10_test_kit/version.rb
+++ b/lib/onc_certification_g10_test_kit/version.rb
@@ -1,3 +1,3 @@
 module ONCCertificationG10TestKit
-  VERSION = '2.3.0'.freeze
+  VERSION = '2.3.0.dev'.freeze
 end


### PR DESCRIPTION
This ensures there is a warning indicating that the copy they are running is not a stable release for certification.