### PR TITLE
FI-1673 Initial pass at bulk data us core 5 validation.

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
@@ -476,5 +476,82 @@ module ONCCertificationG10TestKit
         perform_bulk_export_validation
       end
     end
+
+    if Feature.us_core_v4?
+      test do
+        title 'ServiceRequest resources returned conform to the US Core ServiceRequest Profile'
+        description <<~DESCRIPTION
+          This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        DESCRIPTION
+
+        required_suite_options us_core_version: 'us_core_5'
+
+        include BulkExportValidationTester
+
+        def resource_type
+          'ServiceRequest'
+        end
+
+        run do
+          perform_bulk_export_validation
+        end
+      end
+
+      test do
+        title 'RelatedPerson resources returned conform to the US Core RelatedPerson Profile'
+        description <<~DESCRIPTION
+          This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        DESCRIPTION
+        required_suite_options us_core_version: 'us_core_5'
+
+        include BulkExportValidationTester
+
+        def resource_type
+          'RelatedPerson'
+        end
+
+        run do
+          perform_bulk_export_validation
+        end
+      end
+
+      test do
+        title 'QuestionnaireResponse  resources returned conform to the US Core QuestionnaireResponse Profile if ' \
+              'bulk data has QuestionnaireResponse resources'
+        description <<~DESCRIPTION
+          This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any QuestionnaireResponse resources.
+        DESCRIPTION
+        required_suite_options us_core_version: 'us_core_5'
+
+        include BulkExportValidationTester
+
+        def resource_type
+          'QuesionnaireResponse'
+        end
+
+        run do
+          perform_bulk_export_validation
+        end
+      end
+
+      test do
+        title 'PractionerRole resources returned conform to the US Core PractionerRole Profile if bulk data export ' \
+              'has PractionerRole resources'
+        description <<~DESCRIPTION
+          This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any  resources.
+        DESCRIPTION
+        required_suite_options us_core_version: 'us_core_5'
+
+        include BulkExportValidationTester
+
+        def resource_type
+          'PractitionerRole'
+        end
+
+        run do
+          perform_bulk_export_validation
+        end
+      end
+    end
   end
 end

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
@@ -79,8 +79,9 @@ module ONCCertificationG10TestKit
     test do
       title 'Patient resources returned conform to the US Core Patient Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This#{' '}
-        includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core Patient profile. This includes checking for missing data
+        elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
 
@@ -136,7 +137,9 @@ module ONCCertificationG10TestKit
     test do
       title 'AllergyIntolerance resources returned conform to the US Core AllergyIntolerance Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core AllergyIntolerance profile. This includes
+        checking for missing data elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance'
 
@@ -154,7 +157,9 @@ module ONCCertificationG10TestKit
     test do
       title 'CarePlan resources returned conform to the US Core CarePlan Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core CarePlan profile. This includes checking for
+        missing data elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan'
 
@@ -172,7 +177,9 @@ module ONCCertificationG10TestKit
     test do
       title 'CareTeam resources returned conform to the US Core CareTeam Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core CareTeam profile. This includes checking for missing data
+        elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam'
 
@@ -190,9 +197,21 @@ module ONCCertificationG10TestKit
     test do
       title 'Condition resources returned conform to the relevant US Core Condition Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the server can provide evidence of support for
+        the following US Core Condition profiles.  This includes checking for
+        missing data elements and value set verification.
+
+        For US Core v3.1.1 and v4.0.0 all resources must conform to the following profile:
+
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition
+
+
+        For US Core v5.0.1, evidence of support for the following two profiles must be demonstrated:
+
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns
+
       DESCRIPTION
-      # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition'
 
       include BulkExportValidationTester
 
@@ -208,7 +227,13 @@ module ONCCertificationG10TestKit
     test do
       title 'Device resources returned conform to the US Core Implantable Device Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that relevant resources returned from bulk data export
+        conform to the US Core Implantable Device profile. This includes
+        checking for missing data elements and value set verification.
+
+        Because not all Device resources on a system must conform to the Implantable Device
+        profile, the tester may choose to provide a list of relevant Device Type Codes
+        as an input to this test.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device'
 
@@ -226,12 +251,14 @@ module ONCCertificationG10TestKit
     test do
       title 'DiagnosticReport resources returned conform to the relevant US Core DiagnosticReport Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the following US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the server can provide evidence of support for
+        the following US Core DiagnosticReport profile based on the category of
+        the DiagnosticReport. This includes checking for missing data elements
+        and value set verification.
 
         * http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab
         * http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note
       DESCRIPTION
-      # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-l'
 
       include BulkExportValidationTester
 
@@ -247,7 +274,9 @@ module ONCCertificationG10TestKit
     test do
       title 'DocumentReference resources returned conform to the US Core DocumentReference Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core DocumenReference profile. This includes checking
+        for missing data elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference'
 
@@ -265,7 +294,9 @@ module ONCCertificationG10TestKit
     test do
       title 'Goal resources returned conform to the US Core Goal Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core Goal profile. This includes checking for missing
+        data elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal'
 
@@ -283,7 +314,9 @@ module ONCCertificationG10TestKit
     test do
       title 'Immunization resources returned conform to the US Core Immunization Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core Immunization profile. This includes checking for
+        missing data elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-Immunization'
 
@@ -301,7 +334,9 @@ module ONCCertificationG10TestKit
     test do
       title 'MedicationRequest resources returned conform to the US Core MedicationRequest Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core MedicationRequest profile. This includes checking
+        for missing data elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest'
 
@@ -324,6 +359,8 @@ module ONCCertificationG10TestKit
         associated with the Observation. This includes checking for missing data
         elements and value set verification.
 
+        For US Core v3.1.1, this test expects evidence of the following US Core profiles
+
         * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age
         * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height
         * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
@@ -336,8 +373,47 @@ module ONCCertificationG10TestKit
         * http://hl7.org/fhir/StructureDefinition/bodyweight
         * http://hl7.org/fhir/StructureDefinition/heartrate
         * http://hl7.org/fhir/StructureDefinition/resprate
+
+        For US Core v4.0.0, this test expects evidence of the following US Core profiles
+
+        * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age
+        * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus
+        * http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate
+
+        For US Core v5.0.1, this test expects evidence of the following US Core profiles
+
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-test
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-imaging
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-sexual-orientation
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-social-history
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-sdoh-assessment
+        * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age
+        * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus
+        * http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate
+        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate
+
       DESCRIPTION
-      # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab'
 
       include BulkExportValidationTester
 
@@ -353,7 +429,9 @@ module ONCCertificationG10TestKit
     test do
       title 'Procedure resources returned conform to the US Core Procedure Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core Procedure profile. This includes checking for
+        missing data elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure'
 
@@ -371,7 +449,9 @@ module ONCCertificationG10TestKit
     test do
       title 'Encounter resources returned conform to the US Core Encounter Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core Encounter profile. This includes checking for
+        missing data elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'
 
@@ -389,7 +469,9 @@ module ONCCertificationG10TestKit
     test do
       title 'Organization resources returned conform to the US Core Organization Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core Organization profile. This includes checking for
+        missing data elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization'
 
@@ -407,7 +489,9 @@ module ONCCertificationG10TestKit
     test do
       title 'Practitioner resources returned conform to the US Core Practitioner Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core Practioner profile. This includes checking for
+        missing data elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner'
 
@@ -425,7 +509,9 @@ module ONCCertificationG10TestKit
     test do
       title 'Provenance resources returned conform to the US Core Provenance Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core profiles. This includes checking for missing data
+        elements and value set verification.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance'
 
@@ -444,7 +530,10 @@ module ONCCertificationG10TestKit
       title 'Location resources returned conform to the HL7 FHIR Specification Location Resource if bulk data export ' \
             'has Location resources'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any Location resources.
+        This test verifies that the resources returned from bulk data export
+        conform to the HL7 FHIR Specification Location Resource. This includes
+        checking for missing data elements and value set verification. This test
+        is omitted if bulk data export does not return any Location resources.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-location'
 
@@ -463,7 +552,10 @@ module ONCCertificationG10TestKit
       title 'Medication resources returned conform to the US Core Medication Profile if bulk data export has ' \
             'Medication resources'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any Medication resources.
+        This test verifies that the resources returned from bulk data export
+        conform to the US Core Medication profile, if available. This includes
+        checking for missing data elements and value set verification. This test
+        is omitted if bulk data export does not return any Medication resources.
       DESCRIPTION
       # link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication'
 
@@ -482,7 +574,9 @@ module ONCCertificationG10TestKit
       test do
         title 'ServiceRequest resources returned conform to the US Core ServiceRequest Profile'
         description <<~DESCRIPTION
-          This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+          This test verifies that the resources returned from bulk data export
+          conform to the US Core ServiceRequest profile. This includes checking
+          for missing data elements and value set verification.
         DESCRIPTION
 
         required_suite_options us_core_version: 'us_core_5'
@@ -501,7 +595,9 @@ module ONCCertificationG10TestKit
       test do
         title 'RelatedPerson resources returned conform to the US Core RelatedPerson Profile'
         description <<~DESCRIPTION
-          This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
+          This test verifies that the resources returned from bulk data export
+          conform to the US Core RelatedPerson profile. This includes checking
+          for missing data elements and value set verification.
         DESCRIPTION
         required_suite_options us_core_version: 'us_core_5'
 
@@ -517,10 +613,13 @@ module ONCCertificationG10TestKit
       end
 
       test do
-        title 'QuestionnaireResponse  resources returned conform to the US Core QuestionnaireResponse Profile if ' \
+        title 'QuestionnaireResponse resources returned conform to the US Core QuestionnaireResponse Profile if ' \
               'bulk data has QuestionnaireResponse resources'
         description <<~DESCRIPTION
-          This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any QuestionnaireResponse resources.
+          This test verifies that the resources returned from bulk data export
+          conform to the US Core QuestionnaireResponse profile. This includes checking for missing
+          data elements and value set verification. This test is omitted if bulk
+          data export does not return any QuestionnaireResponse resources.
         DESCRIPTION
         required_suite_options us_core_version: 'us_core_5'
 
@@ -539,7 +638,10 @@ module ONCCertificationG10TestKit
         title 'PractionerRole resources returned conform to the US Core PractionerRole Profile if bulk data export ' \
               'has PractionerRole resources'
         description <<~DESCRIPTION
-          This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification. This test is omitted if bulk data export does not return any  resources.
+          This test verifies that the resources returned from bulk data export
+          conform to the US Core PractitionerRole profile. This includes checking for missing
+          data elements and value set verification. This test is omitted if bulk
+          data export does not return any  resources.
         DESCRIPTION
         required_suite_options us_core_version: 'us_core_5'
 

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
@@ -188,7 +188,7 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'Condition resources returned conform to the US Core Condition Profile'
+      title 'Condition resources returned conform to the relevant US Core Condition Profile'
       description <<~DESCRIPTION
         This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
       DESCRIPTION
@@ -224,7 +224,7 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'DiagnosticReport resources returned conform to the US Core DiagnosticReport Profile'
+      title 'DiagnosticReport resources returned conform to the relevant US Core DiagnosticReport Profile'
       description <<~DESCRIPTION
         This test verifies that the resources returned from bulk data export conform to the following US Core profiles. This includes checking for missing data elements and value set verification.
 
@@ -317,11 +317,12 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'Observation resources returned conform to the US Core Observation Profile'
+      title 'Observation resources returned conform to the relevant US Core Observation Profile'
       description <<~DESCRIPTION
-        This test verifies that the resources returned from bulk data
-        export conform to the following US Core profiles. This includes
-        checking for missing data elements and value set verification.
+        This test verifies that the resources returned from bulk data export
+        conform to the following US Core profiles, based on the category or code
+        associated with the Observation. This includes checking for missing data
+        elements and value set verification.
 
         * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age
         * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height
@@ -526,7 +527,7 @@ module ONCCertificationG10TestKit
         include BulkExportValidationTester
 
         def resource_type
-          'QuesionnaireResponse'
+          'QuestionnaireResponse'
         end
 
         run do

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -1,15 +1,15 @@
-require_relative 'profile_guesser'
+require_relative 'profile_selector'
 
 module ONCCertificationG10TestKit
   module BulkExportValidationTester
     include USCoreTestKit::MustSupportTest
-    include ProfileGuesser
+    include ProfileSelector
 
     attr_reader :metadata
 
     MAX_NUM_COLLECTED_LINES = 100
     MIN_RESOURCE_COUNT = 2
-    OMIT_KLASS = ['Medication', 'Location'].freeze
+    OMIT_KLASS = ['Medication', 'Location', 'QuestionnaireResponse', 'PractitionerRole'].freeze
 
     def versioned_us_core_module
       return USCoreTestKit::USCoreV311 unless Feature.us_core_v4?
@@ -100,7 +100,7 @@ module ONCCertificationG10TestKit
     def determine_profile(resource)
       return if resource.resourceType == 'Device' && !predefined_device_type?(resource)
 
-      guess_profile(resource)
+      select_profile(resource)
     end
 
     def validate_conformance(resources)

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -15,6 +15,8 @@ module ONCCertificationG10TestKit
       return USCoreTestKit::USCoreV311 unless Feature.us_core_v4?
 
       case suite_options[:us_core_version]
+      when 'us_core_5'
+        USCoreTestKit::USCoreV501
       when 'us_core_4'
         USCoreTestKit::USCoreV400
       else

--- a/lib/onc_certification_g10_test_kit/profile_selector.rb
+++ b/lib/onc_certification_g10_test_kit/profile_selector.rb
@@ -3,7 +3,8 @@ module ONCCertificationG10TestKit
     def extract_profile(profile)
       case profile
       when 'Medication'
-        return USCoreTestKit::USCoreV311::USCoreTestSuite.metadata.find do |meta|
+        # TODO: verify why this is the case
+        return versioned_us_core_module.const_get('USCoreTestSuite').metadata.find do |meta|
                  meta.resource == profile
                end.profile_url
       when 'Location'
@@ -63,40 +64,15 @@ module ONCCertificationG10TestKit
           return extract_profile('HeadCircumference') unless Feature.us_core_v4?
 
           case suite_options[:us_core_version]
-          when 'us_core_4'
-            return extract_profile('HeadCircumferencePercentile')
-          else
+          when 'us_core_3'
             return extract_profile('HeadCircumference')
+          else
+            return extract_profile('HeadCircumferencePercentile')
           end
         end
 
         if Feature.us_core_v4?
           return extract_profile('HeadCircumference') if observation_contains_code(resource, '9843-4') # rubocop:disable Style/SoleNestedConditional
-        end
-
-        if Feature.us_core_v4? # New profiles in us core v5
-
-          return extract_profile('ObservationClinicalTest') if suite_options[:us_core_version] == 'us_core_5' &&
-                                                               resource_contains_category(
-                                                                 resource, 'clinical-test', 'http://terminology.hl7.org/CodeSystem/observation-category'
-                                                               )
-
-          return extract_profile('ObservationSexualOrientation') if suite_options[:us_core_version] == 'us_core_5' &&
-                                                                    observation_contains_code(resource, '76690-7')
-
-          return extract_profile('ObservationSocialHistory') if suite_options[:us_core_version] == 'us_core_5' &&
-                                                                resource_contains_category(resource, 'social-history',
-                                                                                           'http://terminology.hl7.org/CodeSystem/observation-category')
-
-          return extract_profile('ObservationSdohAssessment') if suite_options[:us_core_version] == 'us_core_5' &&
-                                                                 resource_contains_category(resource, 'sdoh',
-                                                                                            'http://terminology.hl7.org/CodeSystem/observation-category') && # rubocop:disable Layout/LineLength
-                                                                 resource_contains_category(resource, 'survey', 'http://terminology.hl7.org/CodeSystem/observation-category') # rubocop:disable Layout/LineLength
-
-          return extract_profile('ObservationSurvey') if suite_options[:us_core_version] == 'us_core_5' &&
-                                                         resource_contains_category(
-                                                           resource, 'survey', 'http://terminology.hl7.org/CodeSystem/observation-category'
-                                                         )
         end
 
         # FHIR Vital Signs profiles: https://www.hl7.org/fhir/observation-vitalsigns.html
@@ -114,10 +90,10 @@ module ONCCertificationG10TestKit
           return extract_profile('Bp') unless Feature.us_core_v4?
 
           case suite_options[:us_core_version]
-          when 'us_core_4'
-            return extract_profile('BloodPressure')
-          else
+          when 'us_core_3'
             return extract_profile('Bp')
+          else
+            return extract_profile('BloodPressure')
           end
         end
 
@@ -125,10 +101,10 @@ module ONCCertificationG10TestKit
           return extract_profile('Bodyheight') unless Feature.us_core_v4?
 
           case suite_options[:us_core_version]
-          when 'us_core_4'
-            return extract_profile('BodyHeight')
-          else
+          when 'us_core_3'
             return extract_profile('Bodyheight')
+          else
+            return extract_profile('BodyHeight')
           end
         end
 
@@ -136,10 +112,10 @@ module ONCCertificationG10TestKit
           return extract_profile('Bodytemp') unless Feature.us_core_v4?
 
           case suite_options[:us_core_version]
-          when 'us_core_4'
-            return extract_profile('BodyTemperature')
-          else
+          when 'us_core_3'
             return extract_profile('Bodytemp')
+          else
+            return extract_profile('BodyTemperature')
           end
         end
 
@@ -147,10 +123,10 @@ module ONCCertificationG10TestKit
           return extract_profile('Bodyweight') unless Feature.us_core_v4?
 
           case suite_options[:us_core_version]
-          when 'us_core_4'
-            return extract_profile('BodyWeight')
-          else
+          when 'us_core_3'
             return extract_profile('Bodyweight')
+          else
+            return extract_profile('BodyWeight')
           end
         end
 
@@ -158,10 +134,10 @@ module ONCCertificationG10TestKit
           return extract_profile('Heartrate') unless Feature.us_core_v4?
 
           case suite_options[:us_core_version]
-          when 'us_core_4'
-            return extract_profile('HeartRate')
-          else
+          when 'us_core_3'
             return extract_profile('Heartrate')
+          else
+            return extract_profile('HeartRate')
           end
         end
 
@@ -169,11 +145,40 @@ module ONCCertificationG10TestKit
           return extract_profile('Resprate') unless Feature.us_core_v4?
 
           case suite_options[:us_core_version]
-          when 'us_core_4'
-            return extract_profile('RespiratoryRate')
-          else
+          when 'us_core_3'
             return extract_profile('Resprate')
+          else
+            return extract_profile('RespiratoryRate')
           end
+        end
+        if Feature.us_core_v4? # New profiles in us core v5 based on categories
+
+          return extract_profile('ObservationClinicalTest') if suite_options[:us_core_version] == 'us_core_5' &&
+                                                               resource_contains_category(
+                                                                 resource, 'clinical-test', 'http://terminology.hl7.org/CodeSystem/observation-category'
+                                                               )
+
+          return extract_profile('ObservationSexualOrientation') if suite_options[:us_core_version] == 'us_core_5' &&
+                                                                    observation_contains_code(resource, '76690-7')
+
+          return extract_profile('ObservationSocialHistory') if suite_options[:us_core_version] == 'us_core_5' &&
+                                                                resource_contains_category(resource, 'social-history',
+                                                                                           'http://terminology.hl7.org/CodeSystem/observation-category')
+
+          # We will simply match all Observations of category "survey" to SDOH,
+          # and do not look at the category "sdoh".  US Core spec team says that
+          # support for the "sdoh" category is limited, and the validation rules
+          # allow for very generic surveys to validate against this profile.
+          # And will not validate against the ObservationSurvey profile itself.
+          # This may not be exactly precise but it works out the same
+
+          # if we wanted to be more specific here, we would add:
+          # `resource_contains_category(resource, 'sdoh',
+          #                                       'http://terminology.hl7.org/CodeSystem/observation-category') &&`
+          # along with a specific extract_profile('ObservationSurvey') to catch non-sdoh.
+          return extract_profile('ObservationSdohAssessment') if suite_options[:us_core_version] == 'us_core_5' &&
+                                                                 resource_contains_category(resource, 'survey', 'http://terminology.hl7.org/CodeSystem/observation-category') # rubocop:disable Layout/LineLength
+
         end
 
         nil

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -544,7 +544,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       expect(result.result_message).to start_with('No Observation resources found that conform to profile')
     end
 
-    it 'passes when the profile for every streamed resource needs to be guessed' do
+    it 'passes when the profile for every streamed resource needs to be selected' do
       stub_request(:get, endpoint)
         .with(headers: { 'Accept' => 'application/fhir+ndjson' })
         .to_return(status: 200, body: contents_missing_profile, headers: headers)


### PR DESCRIPTION
Adds additional resource for us_core_5:
* ServiceRequest

Adds additional optional resource types for us_core_5 (omits if none provided):
* RelatedPerson
* PractitionerRole
* QuestionairreResponse

Updates logic for Condition and Observation for choosing relevant profiles.  For Observation relating to SDOH, it only validates against the SDOH profile and not the parent 'survey' profile.

Updated all descriptions as well.

I didn't add self-tests.  I wasn't sure how to handle this with Features and options.  Maybe this is something we can circle back on next month?

To test, update .env to have:

```
US_CORE_4_ENABLED=true
```

And take a look at the US Core 5 vs. US Core 4/3 tests when enabled.