### PR TITLE
FI-1689: SMART v2 scopes

### DIFF
--- a/lib/onc_certification_g10_test_kit/limited_scope_grant_test.rb
+++ b/lib/onc_certification_g10_test_kit/limited_scope_grant_test.rb
@@ -39,9 +39,14 @@ module ONCCertificationG10TestKit
     end
 
     def scope_granting_access?(resource_type, scopes)
-      scopes.any? do |scope|
-        scope.start_with?("patient/#{resource_type}", 'patient/*') && scope.end_with?('*', 'read')
-      end
+      scopes
+        .select { |scope| scope.start_with?("patient/#{resource_type}", 'patient/*') }
+        .any? do |scope|
+          _type, resource_access = scope.split('/')
+          _resource, access_level = resource_access.split('.')
+
+          access_level.match?(/\A(\*|read|c?ru?d?s?\b)/)
+        end
     end
 
     run do

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -142,7 +142,7 @@ module ONCCertificationG10TestKit
           ['openid', 'fhirUser', 'launch', 'offline_access']
         end
 
-        def scope_type
+        def required_scope_type
           'user'
         end
       end
@@ -261,7 +261,7 @@ module ONCCertificationG10TestKit
             ['openid', 'fhirUser', 'launch', 'offline_access']
           end
 
-          def scope_type
+          def required_scope_type
             'user'
           end
         end

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -135,6 +135,9 @@ module ONCCertificationG10TestKit
           inputs: {
             requested_scopes: { name: :ehr_requested_scopes },
             received_scopes: { name: :ehr_received_scopes }
+          },
+          options: {
+            scope_version: :v1
           }
         )
 
@@ -254,6 +257,9 @@ module ONCCertificationG10TestKit
             inputs: {
               requested_scopes: { name: :ehr_requested_scopes },
               received_scopes: { name: :ehr_received_scopes }
+            },
+            options: {
+              scope_version: :v2
             }
           )
 

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -14,9 +14,10 @@ module ONCCertificationG10TestKit
       * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
 
       Enter in the appropriate scope to enable user-level access to all relevant
-      resources. In addition, support for the OpenID Connect (openid fhirUser),
-      refresh tokens (offline_access), and EHR context (launch) are required. This
-      test expects that the EHR will launch the application with a patient context.
+      resources. If using SMART v2, v2-style scopes must be used. In addition,
+      support for the OpenID Connect (openid fhirUser), refresh tokens
+      (offline_access), and EHR context (launch) are required. This test expects
+      that the EHR will launch the application with a patient context.
 
       After submit is pressed, Inferno will wait for the system under test to launch
       the application.

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -238,15 +238,14 @@ module ONCCertificationG10TestKit
           inputs: {
             requested_scopes: {
               default: %(
-                launch openid fhirUser offline_access user/Medication.read
-                user/AllergyIntolerance.read user/CarePlan.read user/CareTeam.read
-                user/Condition.read user/Device.read user/DiagnosticReport.read
-                user/DocumentReference.read user/Encounter.read user/Goal.read
-                user/Immunization.read user/Location.read
-                user/MedicationRequest.read user/Observation.read
-                user/Organization.read user/Patient.read user/Practitioner.read
-                user/Procedure.read user/Provenance.read
-                user/PractitionerRole.read
+                launch openid fhirUser offline_access user/Medication.rs
+                user/AllergyIntolerance.rs user/CarePlan.rs user/CareTeam.rs
+                user/Condition.rs user/Device.rs user/DiagnosticReport.rs
+                user/DocumentReference.rs user/Encounter.rs user/Goal.rs
+                user/Immunization.rs user/Location.rs user/MedicationRequest.rs
+                user/Observation.rs user/Organization.rs user/Patient.rs
+                user/Practitioner.rs user/Procedure.rs user/Provenance.rs
+                user/PractitionerRole.rs
               ).gsub(/\s{2,}/, ' ').strip
             }
           }

--- a/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group.rb
@@ -53,7 +53,19 @@ module ONCCertificationG10TestKit
         },
         requested_scopes: {
           name: :public_requested_scopes,
-          title: 'Public Launch Scope'
+          title: 'Public Launch Scope',
+          default: %(
+            launch/patient openid fhirUser offline_access
+            patient/Medication.read patient/AllergyIntolerance.read
+            patient/CarePlan.read patient/CareTeam.read patient/Condition.read
+            patient/Device.read patient/DiagnosticReport.read
+            patient/DocumentReference.read patient/Encounter.read
+            patient/Goal.read patient/Immunization.read patient/Location.read
+            patient/MedicationRequest.read patient/Observation.read
+            patient/Organization.read patient/Patient.read
+            patient/Practitioner.read patient/Procedure.read
+            patient/Provenance.read patient/PractitionerRole.read
+          ).gsub(/\s{2,}/, ' ').strip
         },
         url: {
           title: 'Public Launch FHIR Endpoint',

--- a/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group.rb
@@ -8,9 +8,9 @@ module ONCCertificationG10TestKit
       * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
 
       Enter in the appropriate scope to enable patient-level access to all
-      relevant resources. In addition, support for the OpenID Connect (openid
-      fhirUser), refresh tokens (offline_access), and patient context
-      (launch/patient) are required.
+      relevant resources. If using SMART v2, v2-style scopes must be used. In
+      addition, support for the OpenID Connect (openid fhirUser), refresh tokens
+      (offline_access), and patient context (launch/patient) are required.
     )
     description %(
       # Background

--- a/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group_stu2.rb
+++ b/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group_stu2.rb
@@ -30,7 +30,18 @@ module ONCCertificationG10TestKit
         },
         requested_scopes: {
           name: :public_requested_scopes,
-          title: 'Public Launch Scope'
+          title: 'Public Launch Scope',
+          default: %(
+            launch/patient openid fhirUser offline_access patient/Medication.rs
+            patient/AllergyIntolerance.rs patient/CarePlan.rs
+            patient/CareTeam.rs patient/Condition.rs patient/Device.rs
+            patient/DiagnosticReport.rs patient/DocumentReference.rs
+            patient/Encounter.rs patient/Goal.rs patient/Immunization.rs
+            patient/Location.rs patient/MedicationRequest.rs
+            patient/Observation.rs patient/Organization.rs patient/Patient.rs
+            patient/Practitioner.rs patient/Procedure.rs patient/Provenance.rs
+            patient/PractitionerRole.rs
+          ).gsub(/\s{2,}/, ' ').strip
         },
         url: {
           title: 'Public Launch FHIR Endpoint',

--- a/lib/onc_certification_g10_test_kit/smart_scopes_test.rb
+++ b/lib/onc_certification_g10_test_kit/smart_scopes_test.rb
@@ -9,68 +9,104 @@ module ONCCertificationG10TestKit
     input :requested_scopes, :received_scopes
     uses_request :token
 
+    VALID_RESOURCE_TYPES = [
+      '*',
+      'Patient',
+      'AllergyIntolerance',
+      'Binary',
+      'CarePlan',
+      'CareTeam',
+      'Condition',
+      'Device',
+      'DiagnosticReport',
+      'DocumentReference',
+      'Encounter',
+      'Goal',
+      'Immunization',
+      'Location',
+      'Medication',
+      'MedicationOrder',
+      'MedicationRequest',
+      'MedicationStatement',
+      'Observation',
+      'Organization',
+      'Person',
+      'Practitioner',
+      'PractitionerRole',
+      'Procedure',
+      'Provenance',
+      'RelatedPerson'
+    ].freeze
+
+    V5_VALID_RESOURCE_TYPES =
+      (VALID_RESOURCE_TYPES + ['ServiceRequest', 'QuestionnaireResponse']).freeze
+
+    PATIENT_COMPARTMENT_RESOURCE_TYPES = [
+      '*',
+      'Patient',
+      'AllergyIntolerance',
+      'CarePlan',
+      'CareTeam',
+      'Condition',
+      'DiagnosticReport',
+      'DocumentReference',
+      'Goal',
+      'Immunization',
+      'MedicationRequest',
+      'Observation',
+      'Procedure',
+      'Provenance'
+    ].freeze
+
+    V5_PATIENT_COMPARTMENT_RESOURCE_TYPES =
+      (PATIENT_COMPARTMENT_RESOURCE_TYPES + ['ServiceRequest']).freeze
+
+    def patient_compartment_resource_types
+      return PATIENT_COMPARTMENT_RESOURCE_TYPES unless suite_options[:us_core_version] == 'us_core_5'
+
+      V5_PATIENT_COMPARTMENT_RESOURCE_TYPES
+    end
+
     def valid_resource_types
-      [
-        '*',
-        'Patient',
-        'AllergyIntolerance',
-        'Binary',
-        'CarePlan',
-        'CareTeam',
-        'Condition',
-        'Device',
-        'DiagnosticReport',
-        'DocumentReference',
-        'Encounter',
-        'Goal',
-        'Immunization',
-        'Location',
-        'Medication',
-        'MedicationOrder',
-        'MedicationRequest',
-        'MedicationStatement',
-        'Observation',
-        'Organization',
-        'Person',
-        'Practitioner',
-        'PractitionerRole',
-        'Procedure',
-        'Provenance',
-        'RelatedPerson'
-      ]
+      return VALID_RESOURCE_TYPES unless suite_options[:us_core_version] == 'us_core_5'
+
+      V5_VALID_RESOURCE_TYPES
     end
 
     def requested_scope_test(scopes, patient_compartment_resource_types)
-      patient_scope_found = false
+      correct_scope_type_found = false
 
       scopes.each do |scope|
         bad_format_message =
-          "Requested scope '#{scope}' does not follow the format: `#{scope_type}" \
+          "Requested scope '#{scope}' does not follow the format: `#{required_scope_type}" \
           '/[ resource | * ].[ read | * ]`'
 
         scope_pieces = scope.split('/')
         assert scope_pieces.count == 2, bad_format_message
+        scope_type, resource_scope = scope_pieces
 
-        resource_access = scope_pieces[1].split('.')
-        bad_resource_message = "'#{resource_access[0]}' must be either a valid resource type or '*'"
+        resource_scope_parts = resource_scope.split('.')
 
-        if scope_type == 'patient' && patient_compartment_resource_types.exclude?(resource_access[0])
-          assert ['user', 'patient'].include?(scope_pieces[0]),
+        resource_type, access_level = resource_scope_parts
+        bad_resource_message = "'#{resource_type}' must be either a valid resource type or '*'"
+
+        if required_scope_type == 'patient' && patient_compartment_resource_types.exclude?(resource_type)
+          assert ['user', 'patient'].include?(scope_type),
                  "Requested scope '#{scope}' must begin with either 'user/' or 'patient/'"
         else
-          assert scope_pieces[0] == scope_type, bad_format_message
+          assert scope_type == required_scope_type, bad_format_message
         end
 
-        assert resource_access.count == 2, bad_format_message
-        assert valid_resource_types.include?(resource_access[0]), bad_resource_message
-        assert resource_access[1] =~ /^(\*|read)/, bad_format_message
+        assert resource_scope_parts.length == 2, bad_format_message
+        assert valid_resource_types.include?(resource_type), bad_resource_message
+        assert access_level =~ /^(\*|read)/, bad_format_message
 
-        patient_scope_found = true
+        correct_scope_type_found = true
       end
 
-      assert patient_scope_found,
-             "#{scope_type.capitalize}-level scope in the format: " \
-             "`#{scope_type}/[ resource | * ].[ read | *]` was not requested."
+      assert correct_scope_type_found,
+             "#{required_scope_type.capitalize}-level scope in the format: " \
+             "`#{required_scope_type}/[ resource | * ].[ read | *]` was not requested."
     end
 
     def received_scope_test(scopes, patient_compartment_resource_types)
@@ -80,10 +116,13 @@ module ONCCertificationG10TestKit
         scope_pieces = scope.split('/')
         next unless scope_pieces.count == 2
 
-        resource_access = scope_pieces[1].split('.')
+        _scope_type, resource_scope = scope_pieces
+
+        resource_scope_parts = resource_scope.split('.')
         next unless resource_access.count == 2
 
-        granted_resource_types << resource_access[0] if resource_access[1] =~ /^(\*|read)/
+        resource_type, access_level = resource_scope_parts
+        granted_resource_types << resource_type if access_level =~ /^(\*|read)/
       end
 
       missing_resource_types =
@@ -99,23 +138,6 @@ module ONCCertificationG10TestKit
 
     run do
       skip_if request.status != 200, 'Token exchange was unsuccessful'
-
-      patient_compartment_resource_types = [
-        '*',
-        'Patient',
-        'AllergyIntolerance',
-        'CarePlan',
-        'CareTeam',
-        'Condition',
-        'DiagnosticReport',
-        'DocumentReference',
-        'Goal',
-        'Immunization',
-        'MedicationRequest',
-        'Observation',
-        'Procedure',
-        'Provenance'
-      ].freeze
 
       [
         {

--- a/lib/onc_certification_g10_test_kit/smart_scopes_test.rb
+++ b/lib/onc_certification_g10_test_kit/smart_scopes_test.rb
@@ -73,19 +73,63 @@ module ONCCertificationG10TestKit
       V5_VALID_RESOURCE_TYPES
     end
 
+    def read_format
+      @read_format ||=
+        begin
+          v1_read_format = 'read'
+          v2_read_format = 'c?ru?d?s?'
+
+          case config.options[:scope_version]
+          when :v1
+            "#{v1_read_format} | *"
+          when :v2
+            "#{v2_read_format} | *"
+          else
+            [v1_read_format, v2_read_format, '*'].join(' | ')
+          end
+        end
+    end
+
+    def access_level_regex
+      @access_level_regex ||=
+        case config.options[:scope_version]
+        when :v1
+          /\A(\*|read)/
+        when :v2
+          /\A(\*|c?ru?d?s?\b)/
+        else
+          /\A(\*|read|c?ru?d?s?\b)/
+        end
+    end
+
+    def bad_format_message(scope)
+      %(
+        Requested scope `#{scope}` does not follow the format:
+        `#{required_scope_type}/[ <ResourceType> | * ].[ #{read_format} ]`
+      )
+    end
+
+    def strip_experimental_scope_syntax(full_scope)
+      if config.options[:scope_version] == :v1
+        full_scope
+      else
+        full_scope.split('?').first
+      end
+    end
+
     def requested_scope_test(scopes, patient_compartment_resource_types)
       correct_scope_type_found = false
 
-      scopes.each do |scope|
-        bad_format_message =
-          "Requested scope '#{scope}' does not follow the format: `#{required_scope_type}" \
-          '/[ resource | * ].[ read | * ]`'
+      scopes.each do |full_scope|
+        scope = strip_experimental_scope_syntax(full_scope)
 
         scope_pieces = scope.split('/')
-        assert scope_pieces.count == 2, bad_format_message
-        scope_type, resource_scope = scope_pieces
+        assert scope_pieces.count == 2, bad_format_message(scope)
 
+        scope_type, resource_scope = scope_pieces
         resource_scope_parts = resource_scope.split('.')
+
+        assert resource_scope_parts.length == 2, bad_format_message(scope)
 
         resource_type, access_level = resource_scope_parts
         bad_resource_message = "'#{resource_type}' must be either a valid resource type or '*'"
@@ -94,35 +138,36 @@ module ONCCertificationG10TestKit
           assert ['user', 'patient'].include?(scope_type),
                  "Requested scope '#{scope}' must begin with either 'user/' or 'patient/'"
         else
-          assert scope_type == required_scope_type, bad_format_message
+          assert scope_type == required_scope_type, bad_format_message(scope)
         end
 
-        assert resource_scope_parts.length == 2, bad_format_message
         assert valid_resource_types.include?(resource_type), bad_resource_message
-        assert access_level =~ /^(\*|read)/, bad_format_message
+        assert access_level =~ access_level_regex, bad_format_message(scope)
 
         correct_scope_type_found = true
       end
 
       assert correct_scope_type_found,
              "#{required_scope_type.capitalize}-level scope in the format: " \
-             "`#{required_scope_type}/[ resource | * ].[ read | *]` was not requested."
+             "`#{required_scope_type}/[ <ResourceType> | * ].[ #{read_format} ]` was not requested."
     end
 
     def received_scope_test(scopes, patient_compartment_resource_types)
       granted_resource_types = []
 
-      scopes.each do |scope|
+      scopes.each do |full_scope|
+        scope = strip_experimental_scope_syntax(full_scope)
+
         scope_pieces = scope.split('/')
         next unless scope_pieces.count == 2
 
         _scope_type, resource_scope = scope_pieces
 
         resource_scope_parts = resource_scope.split('.')
-        next unless resource_access.count == 2
+        next unless resource_scope_parts.count == 2
 
         resource_type, access_level = resource_scope_parts
-        granted_resource_types << resource_type if access_level =~ /^(\*|read)/
+        granted_resource_types << resource_type if access_level =~ access_level_regex
       end
 
       missing_resource_types =

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -131,6 +131,9 @@ module ONCCertificationG10TestKit
           inputs: {
             requested_scopes: { name: :standalone_requested_scopes },
             received_scopes: { name: :standalone_received_scopes }
+          },
+          options: {
+            scope_version: :v1
           }
         )
 
@@ -205,6 +208,9 @@ module ONCCertificationG10TestKit
             inputs: {
               requested_scopes: { name: :standalone_requested_scopes },
               received_scopes: { name: :standalone_received_scopes }
+            },
+            options: {
+              scope_version: :v2
             }
           )
 

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -140,7 +140,7 @@ module ONCCertificationG10TestKit
               patient/Organization.read patient/Patient.read
               patient/Practitioner.read patient/Procedure.read
               patient/Provenance.read patient/PractitionerRole.read
-              ).gsub(/\s{2,}/, ' ').strip
+            ).gsub(/\s{2,}/, ' ').strip
           }
         }
       )

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -126,6 +126,25 @@ module ONCCertificationG10TestKit
           Sequence](http://hl7.org/fhir/smart-app-launch/1.0.0/index.html#standalone-launch-sequence)
       )
 
+      config(
+        inputs: {
+          requested_scopes: {
+            default: %(
+              launch/patient openid fhirUser offline_access
+              patient/Medication.read patient/AllergyIntolerance.read
+              patient/CarePlan.read patient/CareTeam.read patient/Condition.read
+              patient/Device.read patient/DiagnosticReport.read
+              patient/DocumentReference.read patient/Encounter.read
+              patient/Goal.read patient/Immunization.read patient/Location.read
+              patient/MedicationRequest.read patient/Observation.read
+              patient/Organization.read patient/Patient.read
+              patient/Practitioner.read patient/Procedure.read
+              patient/Provenance.read patient/PractitionerRole.read
+              ).gsub(/\s{2,}/, ' ').strip
+          }
+        }
+      )
+
       test from: :g10_smart_scopes do
         config(
           inputs: {
@@ -201,6 +220,25 @@ module ONCCertificationG10TestKit
 
           * [Standalone Launch
             Sequence](http://hl7.org/fhir/smart-app-launch/STU2/app-launch.html#launch-app-standalone-launch)
+        )
+
+        config(
+          inputs: {
+            requested_scopes: {
+              default: %(
+                launch/patient openid fhirUser offline_access
+                patient/Medication.rs patient/AllergyIntolerance.rs
+                patient/CarePlan.rs patient/CareTeam.rs patient/Condition.rs
+                patient/Device.rs patient/DiagnosticReport.rs
+                patient/DocumentReference.rs patient/Encounter.rs
+                patient/Goal.rs patient/Immunization.rs patient/Location.rs
+                patient/MedicationRequest.rs patient/Observation.rs
+                patient/Organization.rs patient/Patient.rs
+                patient/Practitioner.rs patient/Procedure.rs
+                patient/Provenance.rs patient/PractitionerRole.rs
+              ).gsub(/\s{2,}/, ' ').strip
+            }
+          }
         )
 
         test from: :g10_smart_scopes do

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -138,7 +138,7 @@ module ONCCertificationG10TestKit
           ['openid', 'fhirUser', 'launch/patient', 'offline_access']
         end
 
-        def scope_type
+        def required_scope_type
           'patient'
         end
       end
@@ -212,7 +212,7 @@ module ONCCertificationG10TestKit
             ['openid', 'fhirUser', 'launch/patient', 'offline_access']
           end
 
-          def scope_type
+          def required_scope_type
             'patient'
           end
         end


### PR DESCRIPTION
This branch adds support for SMART v2 scopes. When using SMART v2, v2 scopes are required for for the Standalone, Limited, and EHR launches.