### PR TITLE
FI-1658: Add encounter context test to EHR launch group

### DIFF
--- a/lib/onc_certification_g10_test_kit/encounter_context_test.rb
+++ b/lib/onc_certification_g10_test_kit/encounter_context_test.rb
@@ -1,0 +1,30 @@
+module ONCCertificationG10TestKit
+  class EncounterContextTest < Inferno::Test
+    title 'OAuth token exchange response body contains encounter context and encounter resource can be retrieved'
+    description %(
+      The `encounter` field is a String value with a encounter id, indicating that
+      the app was launched in the context of this FHIR Encounter.
+    )
+    id :g10_encounter_context
+    input :encounter_id, :url
+    input :smart_credentials, type: :oauth_credentials
+
+    fhir_client :authenticated do
+      url :url
+      oauth_credentials :smart_credentials
+    end
+
+    run do
+      skip_if smart_credentials.access_token.blank?, 'No access token was received during the SMART launch'
+
+      skip_if encounter_id.blank?, 'Token response did not contain `encounter` field'
+
+      skip_if request.status != 200, 'Token was not successfully refreshed' if config.options[:refresh_test]
+
+      fhir_read(:encounter, encounter_id, client: :authenticated)
+
+      assert_response_status(200)
+      assert_resource_type(:encounter)
+    end
+  end
+end

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -2,6 +2,7 @@ require_relative 'base_token_refresh_group'
 require_relative 'smart_scopes_test'
 require_relative 'unauthorized_access_test'
 require_relative 'well_known_capabilities_test'
+require_relative 'encounter_context_test' if ONCCertificationG10TestKit::Feature.us_core_v4?
 
 module ONCCertificationG10TestKit
   class SmartEHRPractitionerAppGroup < Inferno::TestGroup
@@ -162,6 +163,17 @@ module ONCCertificationG10TestKit
              }
            }
 
+      if Feature.us_core_v4?
+        test from: :g10_encounter_context,
+             config: {
+               inputs: {
+                 encounter_id: { name: :ehr_encounter_id },
+                 access_token: { name: :ehr_access_token }
+               }
+             },
+             required_suite_options: { us_core_version: 'us_core_5' }
+      end
+
       test do
         title 'Launch context contains smart_style_url which links to valid JSON'
         description %(
@@ -169,6 +181,7 @@ module ONCCertificationG10TestKit
           can check for the existence of this launch context parameter and
           download the JSON file referenced by the URL value.
         )
+        id :Test13
         uses_request :token
 
         run do
@@ -194,6 +207,7 @@ module ONCCertificationG10TestKit
           was launched in a UX context where a patient banner is required (when
           true) or not required (when false).
         )
+        id :Test14
         uses_request :token
 
         run do
@@ -281,6 +295,17 @@ module ONCCertificationG10TestKit
                }
              }
 
+        if Feature.us_core_v4?
+          test from: :g10_encounter_context,
+               config: {
+                 inputs: {
+                   encounter_id: { name: :ehr_encounter_id },
+                   access_token: { name: :ehr_access_token }
+                 }
+               },
+               required_suite_options: { us_core_version: 'us_core_5' }
+        end
+
         test do
           title 'Launch context contains smart_style_url which links to valid JSON'
           description %(
@@ -289,6 +314,7 @@ module ONCCertificationG10TestKit
             download the JSON file referenced by the URL value.
           )
           uses_request :token
+          id :g10_smart_style_url
 
           run do
             skip_if request.status != 200, 'No token response received'
@@ -314,6 +340,7 @@ module ONCCertificationG10TestKit
             true) or not required (when false).
           )
           uses_request :token
+          id :g10_smart_need_patient_banner
 
           run do
             skip_if request.status != 200, 'No token response received'

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -95,7 +95,6 @@ module ONCCertificationG10TestKit
                    'authorize-post',
                    'permission-v1',
                    'permission-v2'
-
                  ]
                }
              }

--- a/lib/onc_certification_g10_test_kit/well_known_capabilities_test.rb
+++ b/lib/onc_certification_g10_test_kit/well_known_capabilities_test.rb
@@ -19,7 +19,13 @@ module ONCCertificationG10TestKit
       assert capabilities.is_a?(Array),
              "Expected the well-known capabilities to be an Array, but found #{capabilities.class.name}"
 
-      missing_capabilities = (config.options[:required_capabilities] || []) - capabilities
+      required_capabilities = config.options[:required_capabilities] || []
+
+      if suite_options[:us_core_version] == 'us_core_5' && required_capabilities.include?('launch-ehr')
+        required_capabilities << 'context-ehr-encounter'
+      end
+
+      missing_capabilities = required_capabilities - capabilities
       assert missing_capabilities.empty?,
              "The following capabilities required for this scenario are missing: #{missing_capabilities.join(', ')}"
     end


### PR DESCRIPTION
Encounter is in USCDI v2, so the Encounter context should be tested when using US Core 5. If you run the EHR launch with US Core 5, you should see the encounter test.