### PR TITLE
Add filters for invalid Coding error

### DIFF
--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -80,6 +80,7 @@ module ONCCertificationG10TestKit
              message.type == 'error' && (
                message.message.match?(/\A\S+: \S+: Unknown Code/) ||
                message.message.match?(/\A\S+: \S+: None of the codings provided are in the value set/)
+               message.message.match?(/\A\S+: \S+: The Coding provided \(\S*\) is not in the value set/)
              )
            )
           true

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -79,7 +79,7 @@ module ONCCertificationG10TestKit
            (
              message.type == 'error' && (
                message.message.match?(/\A\S+: \S+: Unknown Code/) ||
-               message.message.match?(/\A\S+: \S+: None of the codings provided are in the value set/)
+               message.message.match?(/\A\S+: \S+: None of the codings provided are in the value set/) ||
                message.message.match?(/\A\S+: \S+: The Coding provided \(\S*\) is not in the value set/)
              )
            )

--- a/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
@@ -17,7 +17,29 @@ RSpec.describe 'Resource Validation' do # rubocop:disable RSpec/DescribeClass
     expect(runnable.messages.length).to be_zero
   end
 
-  it 'excludes codings not in VS messages' do
+  it 'excludes CodeableConcept not in VS messages' do
+    stub_request(:post, "#{validator_url}/validate?profile=PROFILE")
+      .to_return(status: 200, body: operation_outcome_string2)
+
+    expect(runnable.resource_is_valid?(resource: resource, profile_url: 'PROFILE')).to be(true)
+    expect(runnable.messages.length).to be_zero
+  end
+
+  it 'excludes Coding not in VS messages' do
+    oo = FHIR::OperationOutcome.new(
+      issue: [
+        {
+          severity: 'error',
+          code: 'code-invalid',
+          details: {
+            text: 'The Coding provided (urn:oid:2.16.840.1.113883.6.238#2106-3) is not in the value set http://hl7.org/fhir/us/core/ValueSet/omb-race-category, and a code is required from this value set. (error message = Not in value set http://hl7.org/fhir/us/core/ValueSet/omb-race-category)'
+          },
+          expression: [
+            'Patient.extension[0].extension[0].value.ofType(Coding)'
+          ]
+       }
+      ]
+    )
     stub_request(:post, "#{validator_url}/validate?profile=PROFILE")
       .to_return(status: 200, body: operation_outcome_string2)
 

--- a/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
@@ -32,16 +32,19 @@ RSpec.describe 'Resource Validation' do # rubocop:disable RSpec/DescribeClass
           severity: 'error',
           code: 'code-invalid',
           details: {
-            text: 'The Coding provided (urn:oid:2.16.840.1.113883.6.238#2106-3) is not in the value set http://hl7.org/fhir/us/core/ValueSet/omb-race-category, and a code is required from this value set. (error message = Not in value set http://hl7.org/fhir/us/core/ValueSet/omb-race-category)'
+            text: 'The Coding provided (urn:oid:2.16.840.1.113883.6.238#2106-3) is not in the value set ' \
+                  'http://hl7.org/fhir/us/core/ValueSet/omb-race-category, and a code is required from ' \
+                  'this value set. (error message = Not in value set ' \
+                  'http://hl7.org/fhir/us/core/ValueSet/omb-race-category)'
           },
           expression: [
             'Patient.extension[0].extension[0].value.ofType(Coding)'
           ]
-       }
+        }
       ]
     )
     stub_request(:post, "#{validator_url}/validate?profile=PROFILE")
-      .to_return(status: 200, body: operation_outcome_string2)
+      .to_return(status: 200, body: oo.to_json)
 
     expect(runnable.resource_is_valid?(resource: resource, profile_url: 'PROFILE')).to be(true)
     expect(runnable.messages.length).to be_zero


### PR DESCRIPTION
Add filter for validator's invalid coding error message.

How to test:

Run latest (g)(10) test suite.
Patient validation test shall pass