### PR TITLE
FI-1700: Encode Param in _outputFormat Test

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_stu2.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_stu2.rb
@@ -32,7 +32,7 @@ module ONCCertificationG10TestKit
 
       run do
         ['application/fhir+ndjson', 'application/ndjson', 'ndjson'].each do |format|
-          perform_export_kick_off_request(params: "_outputFormat=#{format}")
+          perform_export_kick_off_request(params: { _outputFormat: format })
           assert_response_status(202)
 
           delete_export_kick_off_request

--- a/lib/onc_certification_g10_test_kit/export_kick_off_performer.rb
+++ b/lib/onc_certification_g10_test_kit/export_kick_off_performer.rb
@@ -1,13 +1,14 @@
 module ONCCertificationG10TestKit
   module ExportKickOffPerformer
-    def perform_export_kick_off_request(use_token: true, params: '')
+    def perform_export_kick_off_request(use_token: true, params: {})
       skip_if use_token && bearer_token.blank?, 'Could not verify this functionality when bearer token is not set'
 
       headers = { accept: 'application/fhir+json', prefer: 'respond-async' }
       headers.merge!({ authorization: "Bearer #{bearer_token}" }) if use_token
 
       url = "Group/#{group_id}/$export"
-      url.concat("?#{params}") unless params.empty?
+      param_str = params.map { |k, v| URI.encode_www_form(k => v) }.join("&")
+      url.concat("?#{param_str}") unless param_str.empty?
       get(url, client: :bulk_server, name: :export, headers: headers)
     end
 

--- a/lib/onc_certification_g10_test_kit/export_kick_off_performer.rb
+++ b/lib/onc_certification_g10_test_kit/export_kick_off_performer.rb
@@ -7,7 +7,7 @@ module ONCCertificationG10TestKit
       headers.merge!({ authorization: "Bearer #{bearer_token}" }) if use_token
 
       url = "Group/#{group_id}/$export"
-      param_str = params.map { |k, v| URI.encode_www_form(k => v) }.join("&")
+      param_str = params.map { |k, v| URI.encode_www_form(k => v) }.join('&')
       url.concat("?#{param_str}") unless param_str.empty?
       get(url, client: :bulk_server, name: :export, headers: headers)
     end

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_stu2_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_stu2_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportSTU2 do
   describe '[Bulk Data Server supports "_outputFormat" query parameter] test' do
     let(:runnable) { group.tests.last }
     let(:long_format_req) do
-      stub_request(:get, "#{export_url}?_outputFormat=application/fhir+ndjson")
+      stub_request(:get, "#{export_url}?_outputFormat=application/fhir%2Bndjson")
         .to_return(status: 202, headers: { 'Content-Location' => polling_url })
     end
     let(:medium_format_req) do
@@ -51,7 +51,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportSTU2 do
     end
 
     it 'fails when server does not support any ndjson content types' do
-      stub_request(:get, "#{export_url}?_outputFormat=application/fhir+ndjson")
+      stub_request(:get, "#{export_url}?_outputFormat=application/fhir%2Bndjson")
         .to_return(status: 400)
 
       result = run(runnable, input)

--- a/spec/onc_certification_g10_test_kit/export_kick_off_performer_spec.rb
+++ b/spec/onc_certification_g10_test_kit/export_kick_off_performer_spec.rb
@@ -12,12 +12,12 @@ end
 RSpec.describe ONCCertificationG10TestKit::ExportKickOffPerformer do
   let(:token) { 'some_token' }
   let(:group_id) { 'some_group_id' }
-  let(:param) { '_outputFormat=ndjson' }
   let(:bulk_server_url) { 'https://www.example.com' }
   let(:polling_url) { 'https://www.some_polling_url.com' }
   let(:performer) { ExportKickOffPerformerTesterClass.new }
   let(:request) { Inferno::Entities::Request.new({ headers: [header] }) }
   let(:bulk_export_url) { "#{bulk_server_url}/Group/#{group_id}/$export" }
+  let(:params) { { _outputFormat: 'appplication/fhir+ndjson', _sort: 'sample+value' } }
   let(:header) do
     Inferno::Entities::Header.new({
                                     name: 'content-location', type: 'response', value: polling_url
@@ -65,12 +65,21 @@ RSpec.describe ONCCertificationG10TestKit::ExportKickOffPerformer do
       expect(token_header_req).to have_been_made.once
     end
 
-    it 'includes params in request url if params' do
-      params_url_req = stub_request(:get, "#{bulk_export_url}?#{param}")
+    it 'includes single param in request url if param' do
+      params_url_req = stub_request(:get, "#{bulk_export_url}?_outputFormat=appplication/fhir%2Bndjson")
         .with(headers: { 'authorization' => "Bearer #{token}" })
         .to_return(status: 200)
 
-      performer.perform_export_kick_off_request(params: param)
+      performer.perform_export_kick_off_request(params: { _outputFormat: 'appplication/fhir+ndjson' } )
+      expect(params_url_req).to have_been_made.once
+    end
+
+    it 'includes multiple params in request url if params' do
+      params_url_req = stub_request(:get, "#{bulk_export_url}?_outputFormat=appplication/fhir%2Bndjson&_sort=sample%2Bvalue")
+        .with(headers: { 'authorization' => "Bearer #{token}" })
+        .to_return(status: 200)
+
+      performer.perform_export_kick_off_request(params: params)
       expect(params_url_req).to have_been_made.once
     end
 

--- a/spec/onc_certification_g10_test_kit/export_kick_off_performer_spec.rb
+++ b/spec/onc_certification_g10_test_kit/export_kick_off_performer_spec.rb
@@ -70,12 +70,13 @@ RSpec.describe ONCCertificationG10TestKit::ExportKickOffPerformer do
         .with(headers: { 'authorization' => "Bearer #{token}" })
         .to_return(status: 200)
 
-      performer.perform_export_kick_off_request(params: { _outputFormat: 'appplication/fhir+ndjson' } )
+      performer.perform_export_kick_off_request(params: { _outputFormat: 'appplication/fhir+ndjson' })
       expect(params_url_req).to have_been_made.once
     end
 
     it 'includes multiple params in request url if params' do
-      params_url_req = stub_request(:get, "#{bulk_export_url}?_outputFormat=appplication/fhir%2Bndjson&_sort=sample%2Bvalue")
+      params_url_req = stub_request(:get,
+                                    "#{bulk_export_url}?_outputFormat=appplication/fhir%2Bndjson&_sort=sample%2Bvalue")
         .with(headers: { 'authorization' => "Bearer #{token}" })
         .to_return(status: 200)
 


### PR DESCRIPTION
Updated the export performer to take in a hash of params and encode each param before appending them to the url. 

To test, run the Multi-Patient API STU2 group and confirm that Test 8.2.08 passes as expected.