### PR TITLE
FI-1702: Fix head circumference bulk data profile

### DIFF
--- a/lib/onc_certification_g10_test_kit/profile_selector.rb
+++ b/lib/onc_certification_g10_test_kit/profile_selector.rb
@@ -64,7 +64,9 @@ module ONCCertificationG10TestKit
           end
         end
 
-        return extract_profile('HeadCircumference') if observation_contains_code(resource, '9843-4')
+        if observation_contains_code(resource, '9843-4') && suite_options[:us_core_version] != 'us_core_3'
+          return extract_profile('HeadCircumference')
+        end
 
         # FHIR Vital Signs profiles: https://www.hl7.org/fhir/observation-vitalsigns.html
         # Vital Signs Panel, Oxygen Saturation are not required by USCDI

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -394,103 +394,112 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
       end
     end
 
-    context 'with Observation resource' do
-      let(:observation) do
-        coding = FHIR::Coding.new({ code: '72166-2' })
-        code = FHIR::CodeableConcept.new({ coding: [coding] })
-        FHIR::Observation.new({ code: code })
-      end
+    context 'when using US Core 3.1.1' do
+      context 'with Observation resource' do
+        let(:observation) do
+          coding = FHIR::Coding.new({ code: '72166-2' })
+          code = FHIR::CodeableConcept.new({ coding: [coding] })
+          FHIR::Observation.new({ code: code })
+        end
 
-      it 'returns the SmokingStatus profile if resource has SmokingStatus criterion specified' do
-        result = tester.determine_profile(observation)
-        expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus')
-      end
+        it 'returns the SmokingStatus profile if resource has SmokingStatus criterion specified' do
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus')
+        end
 
-      it 'returns the ObservationLab profile if resource has ObservationLab criterion specified' do
-        coding = FHIR::Coding.new({ code: 'laboratory',
-                                    system: 'http://terminology.hl7.org/CodeSystem/observation-category' })
-        category = FHIR::CodeableConcept.new({ coding: [coding] })
-        observation = FHIR::Observation.new({ category: [category] })
+        it 'returns the ObservationLab profile if resource has ObservationLab criterion specified' do
+          coding = FHIR::Coding.new({ code: 'laboratory',
+                                      system: 'http://terminology.hl7.org/CodeSystem/observation-category' })
+          category = FHIR::CodeableConcept.new({ coding: [coding] })
+          observation = FHIR::Observation.new({ category: [category] })
 
-        result = tester.determine_profile(observation)
-        expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab')
-      end
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab')
+        end
 
-      it 'returns the PediatricBmiForAge profile if resource has PediatricBmiForAge criterion specified' do
-        observation.code.coding[0].code = '59576-9'
+        it 'returns the PediatricBmiForAge profile if resource has PediatricBmiForAge criterion specified' do
+          observation.code.coding[0].code = '59576-9'
 
-        result = tester.determine_profile(observation)
-        expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age')
-      end
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age')
+        end
 
-      it 'returns the PediatricWeightForHeight profile if resource has PediatricWeightForHeight criterion specified' do
-        observation.code.coding[0].code = '77606-2'
+        it 'returns the PediatricWeightForHeight profile if resource has PediatricWeightForHeight code' do
+          observation.code.coding[0].code = '77606-2'
 
-        result = tester.determine_profile(observation)
-        expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height')
-      end
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height')
+        end
 
-      it 'returns the PulseOximetry profile if resource has PulseOximetry criterion specified' do
-        observation.code.coding[0].code = '59408-5'
+        it 'returns the PulseOximetry profile if resource has PulseOximetry criterion specified' do
+          observation.code.coding[0].code = '59408-5'
 
-        result = tester.determine_profile(observation)
-        expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry')
-      end
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry')
+        end
 
-      it 'returns the HeadCircumference profile if resource has HeadCircumference criterion specified' do
-        observation.code.coding[0].code = '8289-1'
+        it 'returns the HeadCircumference profile if resource has HeadCircumference criterion specified' do
+          observation.code.coding[0].code = '8289-1'
 
-        result = tester.determine_profile(observation)
-        expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile')
-      end
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile')
+        end
 
-      it 'returns the Bp profile if resource has Bp criterion specified' do
-        observation.code.coding[0].code = '85354-9'
+        it 'returns the Bp profile if resource has Bp criterion specified' do
+          observation.code.coding[0].code = '85354-9'
 
-        result = tester.determine_profile(observation)
-        expect(result).to eq('http://hl7.org/fhir/StructureDefinition/bp')
-      end
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/StructureDefinition/bp')
+        end
 
-      it 'returns the Bodyheight profile if resource has Bodyheight criterion specified' do
-        observation.code.coding[0].code = '8302-2'
+        it 'returns the Bodyheight profile if resource has Bodyheight criterion specified' do
+          observation.code.coding[0].code = '8302-2'
 
-        result = tester.determine_profile(observation)
-        expect(result).to eq('http://hl7.org/fhir/StructureDefinition/bodyheight')
-      end
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/StructureDefinition/bodyheight')
+        end
 
-      it 'returns the Bodytemp profile if resource has Bodytemp criterion specified' do
-        observation.code.coding[0].code = '8310-5'
+        it 'returns the Bodytemp profile if resource has Bodytemp criterion specified' do
+          observation.code.coding[0].code = '8310-5'
 
-        result = tester.determine_profile(observation)
-        expect(result).to eq('http://hl7.org/fhir/StructureDefinition/bodytemp')
-      end
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/StructureDefinition/bodytemp')
+        end
 
-      it 'returns the Bodyweight profile if resource has Bodyweight criterion specified' do
-        observation.code.coding[0].code = '29463-7'
+        it 'returns the Bodyweight profile if resource has Bodyweight criterion specified' do
+          observation.code.coding[0].code = '29463-7'
 
-        result = tester.determine_profile(observation)
-        expect(result).to eq('http://hl7.org/fhir/StructureDefinition/bodyweight')
-      end
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/StructureDefinition/bodyweight')
+        end
 
-      it 'returns the Heartrate profile if resource has Heartrate criterion specified' do
-        observation.code.coding[0].code = '8867-4'
+        it 'returns the Heartrate profile if resource has Heartrate criterion specified' do
+          observation.code.coding[0].code = '8867-4'
 
-        result = tester.determine_profile(observation)
-        expect(result).to eq('http://hl7.org/fhir/StructureDefinition/heartrate')
-      end
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/StructureDefinition/heartrate')
+        end
 
-      it 'returns the Resprate profile if resource has Resprate criterion specified' do
-        observation.code.coding[0].code = '9279-1'
+        it 'returns the Resprate profile if resource has Resprate criterion specified' do
+          observation.code.coding[0].code = '9279-1'
 
-        result = tester.determine_profile(observation)
-        expect(result).to eq('http://hl7.org/fhir/StructureDefinition/resprate')
-      end
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/StructureDefinition/resprate')
+        end
 
-      it 'returns nil when given none of the possible sets of profile criterion' do
-        observation.code.coding[0].code = 'bad_code'
+        it 'returns nil when given none of the possible sets of profile criterion' do
+          observation.code.coding[0].code = 'bad_code'
 
-        result = tester.determine_profile(observation)
-        expect(result).to be_nil
+          result = tester.determine_profile(observation)
+          expect(result).to be_nil
+        end
+
+        it 'returns nil when the Observation contains a head circumference code' do
+          observation.code.coding[0].code = '9843-4'
+
+          result = tester.determine_profile(observation)
+          expect(result).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
This branch prevents Head Circumference (not percentile Head Circumference) resources in the bulk data tests from being validated when US Core 3 is being used (reported in #238).