### PR TITLE
FI-1718: Handle imaging result profile in bulk data

### DIFF
--- a/lib/onc_certification_g10_test_kit/profile_selector.rb
+++ b/lib/onc_certification_g10_test_kit/profile_selector.rb
@@ -148,6 +148,12 @@ module ONCCertificationG10TestKit
           return extract_profile('ObservationSocialHistory')
         end
 
+        if suite_options[:us_core_version] == 'us_core_5' &&
+           resource_contains_category(resource, 'imaging',
+                                      'http://terminology.hl7.org/CodeSystem/observation-category')
+          return extract_profile('ObservationImaging')
+        end
+
         # We will simply match all Observations of category "survey" to SDOH,
         # and do not look at the category "sdoh".  US Core spec team says that
         # support for the "sdoh" category is limited, and the validation rules

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -394,8 +394,22 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
       end
     end
 
-    context 'when using US Core 3.1.1' do
-      context 'with Observation resource' do
+    context 'with Observation resource' do
+      context 'when using US Core 5.0.1' do
+        it 'returns the SmokingStatus profile if resource has SmokingStatus criterion specified' do
+          allow(tester).to receive(:suite_options).and_return({ us_core_version: 'us_core_5' })
+
+          coding = FHIR::Coding.new({ code: 'imaging',
+                                      system: 'http://terminology.hl7.org/CodeSystem/observation-category' })
+          category = FHIR::CodeableConcept.new({ coding: [coding] })
+          observation = FHIR::Observation.new({ category: [category] })
+
+          result = tester.determine_profile(observation)
+          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-imaging')
+        end
+      end
+
+      context 'when using US Core 3.1.1' do
         let(:observation) do
           coding = FHIR::Coding.new({ code: '72166-2' })
           code = FHIR::CodeableConcept.new({ coding: [coding] })


### PR DESCRIPTION
Adds support for the Observation Imaging Result profile in bulk data when using US Core 5.