### PR TITLE
FI-1730: Check that json is valid before parsing

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_stu1.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_stu1.rb
@@ -221,6 +221,7 @@ module ONCCertificationG10TestKit
         assert request.response_header('content-type')&.value&.include?('application/json'),
                'Content-Type not application/json'
 
+        assert_valid_json(response[:body])
         response_body = JSON.parse(response[:body])
 
         ['transactionTime', 'request', 'requiresAccessToken', 'output', 'error'].each do |key|
@@ -255,6 +256,7 @@ module ONCCertificationG10TestKit
       run do
         assert status_response.present?, 'Bulk Data Server status response not found'
 
+        assert_valid_json(status_response)
         status_output = JSON.parse(status_response)['output']
         assert status_output, 'Bulk Data Server status response does not contain output'
 

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -197,6 +197,7 @@ module ONCCertificationG10TestKit
       skip_if (requires_access_token == 'true' && bearer_token.blank?),
               'Could not verify this functionality when Bearer Token is required and not provided'
 
+      assert_valid_json(status_output)
       file_list = JSON.parse(status_output).select { |file| file['type'] == resource_type }
       if file_list.empty?
         message = "No #{resource_type} resource file item returned by server."

--- a/lib/onc_certification_g10_test_kit/resource_access_test.rb
+++ b/lib/onc_certification_g10_test_kit/resource_access_test.rb
@@ -74,10 +74,9 @@ module ONCCertificationG10TestKit
             body of the response.
           )
           begin
+            assert_valid_json(response[:body])
             parsed_body = JSON.parse(response[:body])
             assert parsed_body['resourceType'] == 'OperationOutcome', error_message
-          rescue JSON::ParserError
-            assert false, error_message
           end
           fhir_search(
             resource_type,


### PR DESCRIPTION
Check that json is valid to prevent purple json parsing errors (#275).