### PR TITLE
patient/ServiceRequest.rs added to scopes

### DIFF
--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -239,7 +239,7 @@ module ONCCertificationG10TestKit
               patient/MedicationRequest.rs patient/Observation.rs
               patient/Organization.rs patient/Patient.rs
               patient/Practitioner.rs patient/Procedure.rs
-              patient/Provenance.rs patient/PractitionerRole.rs
+              patient/Provenance.rs patient/PractitionerRole.rs patient/ServiceRequest.rs
             ).gsub(/\s{2,}/, ' ').strip
           }
         }


### PR DESCRIPTION
patient/ServiceRequest.rs needs to be present here to get access to the ServiceRequest resource. Access to ServiceRequest is validated in the tests ahead.