### PR TITLE
Fix CodeSystem metadata path

### DIFF
--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -43,7 +43,7 @@ module ONCCertificationG10TestKit
     end
 
     def code_system_version_messages
-      path = File.join(__dir__, '..', '..', 'resources', 'terminology', 'validators', 'bloom', 'metadata.yml')
+      path = File.join('resources', 'terminology', 'validators', 'bloom', 'metadata.yml')
       return '' unless File.exist? path
 
       cs_metadata = YAML.load_file(path)


### PR DESCRIPTION
If you look at the g10 config info messages on inferno-dev, you should see this, which means this works:

![Screen Shot 2022-10-07 at 9 38 27 AM](https://user-images.githubusercontent.com/15969967/194567099-0d6396ba-8f19-4259-aee5-3ef22ac52793.png)
