### PR TITLE
Specify `INFERNO_HOST` env variable for the two `inferno` services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   inferno:
     build:
       context: ./
+    environment:
+      INFERNO_HOST: "${INFERNO_HOST}"
     volumes:
       - ./data:/opt/inferno/data
     depends_on:
@@ -38,6 +40,8 @@ services:
   worker:
     build:
       context: ./
+    environment:
+      INFERNO_HOST: "${INFERNO_HOST}"
     volumes:
       - ./data:/opt/inferno/data
     command: bundle exec sidekiq -r ./worker.rb


### PR DESCRIPTION
I ran into an issue where the `INFERNO_HOST` environment variable isn't getting set inside the containers that use it, even though these issues indicate it's the proper way to specify it:

- https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/277
- https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/318

This fix allowed us to override `http://localhost` with the proper value we required.