### PR TITLE
FI-1780: Fix terminology checking

### DIFF
--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -90,6 +90,9 @@ module ONCCertificationG10TestKit
                           when '5.0.1'
                             '501'
                           else
+                            # This open-ended else is primarily for Vital Signs profiles in v3.1.1, which are tagged 
+                            # with the base FHIR version (4.0.1).  The profiles were migrated to US Core in later
+                            # versions.
                             '311'
                           end
 

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -83,10 +83,20 @@ module ONCCertificationG10TestKit
       end
 
       perform_additional_validation do |resource, profile_url|
-        metadata = USCoreTestKit::USCoreV311::USCoreTestSuite.metadata.find do |metadata_candidate|
-          metadata_candidate.profile_url == profile_url
-        end
+        versionless_profile_url, profile_version = profile_url.split('|')
+        profile_version = case profile_version
+                          when '4.0.0'
+                            '400'
+                          when '5.0.1'
+                            '501'
+                          else
+                            '311'
+                          end
 
+        us_core_suite = USCoreTestKit.const_get("USCoreV#{profile_version}")::USCoreTestSuite
+        metadata = us_core_suite.metadata.find do |metadata_candidate|
+          metadata_candidate.profile_url == versionless_profile_url
+        end
         next if metadata.nil?
 
         metadata.bindings

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -90,7 +90,7 @@ module ONCCertificationG10TestKit
                           when '5.0.1'
                             '501'
                           else
-                            # This open-ended else is primarily for Vital Signs profiles in v3.1.1, which are tagged 
+                            # This open-ended else is primarily for Vital Signs profiles in v3.1.1, which are tagged
                             # with the base FHIR version (4.0.1).  The profiles were migrated to US Core in later
                             # versions.
                             '311'


### PR DESCRIPTION
This fixes terminology validation.

If you run the tests against inferno-dev, you should see three terminology errors in the patient tests that you don't see on `main` (see #320).