### PR TITLE
FI-1781: Fix clinical test observations in bulk data

### DIFF
--- a/lib/onc_certification_g10_test_kit/profile_selector.rb
+++ b/lib/onc_certification_g10_test_kit/profile_selector.rb
@@ -135,7 +135,7 @@ module ONCCertificationG10TestKit
 
         if using_us_core_5? &&
            resource_contains_category(
-             resource, 'clinical-test', 'http://terminology.hl7.org/CodeSystem/observation-category'
+             resource, 'clinical-test', 'http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category'
            )
           return extract_profile('ObservationClinicalTest')
         end


### PR DESCRIPTION
Clinical test observations in US Core 5 were not being correctly identified in the bulk data tests due to an incorrect system url (see #327).