### PR TITLE
FI-1779: Verify EHR patient launch scopes

### DIFF
--- a/lib/onc_certification_g10_test_kit/patient_scope_test.rb
+++ b/lib/onc_certification_g10_test_kit/patient_scope_test.rb
@@ -1,0 +1,25 @@
+module ONCCertificationG10TestKit
+  class PatientScopeTest < Inferno::Test
+    title 'Patient-level scopes were granted'
+    description %(
+      Systems are required to support the `permission-patient` capability as
+      part of the [Clinician Access for EHR Launch Capability
+      Set.](http://hl7.org/fhir/smart-app-launch/1.0.0/conformance/index.html#clinician-access-for-ehr-launch)
+
+      This test verifies that systems are capable of granting patient-level
+      scopes during an EHR Launch.
+    )
+    id :g10_patient_scope
+    input :received_scopes
+
+    run do
+      expected_scope = if config.options[:scope_version] == :v2
+                         'patient/Patient.rs'
+                       else
+                         'patient/Patient.read'
+                       end
+      assert received_scopes&.include?(expected_scope),
+             "#{expected_scope} scope was requested, but not received. Received: `#{received_scopes}`"
+    end
+  end
+end

--- a/lib/onc_certification_g10_test_kit/short_id_map.yml
+++ b/lib/onc_certification_g10_test_kit/short_id_map.yml
@@ -1507,6 +1507,7 @@ g10_certification-Group06-g10_ehr_patient_launch-smart_token_exchange: 9.8.07
 g10_certification-Group06-g10_ehr_patient_launch-smart_token_response_body: 9.8.08
 g10_certification-Group06-g10_ehr_patient_launch-smart_token_response_headers: 9.8.09
 g10_certification-Group06-g10_ehr_patient_launch-g10_patient_context: 9.8.10
+g10_certification-Group06-g10_ehr_patient_launch-g10_patient_scope: 9.8.11
 g10_certification-Group06-g10_ehr_patient_launch_stu2: '9.9'
 g10_certification-Group06-g10_ehr_patient_launch_stu2-smart_app_launch: 9.9.01
 g10_certification-Group06-g10_ehr_patient_launch_stu2-smart_launch_received: 9.9.02
@@ -1518,6 +1519,7 @@ g10_certification-Group06-g10_ehr_patient_launch_stu2-smart_token_exchange: 9.9.
 g10_certification-Group06-g10_ehr_patient_launch_stu2-smart_token_response_body: 9.9.08
 g10_certification-Group06-g10_ehr_patient_launch_stu2-smart_token_response_headers: 9.9.09
 g10_certification-Group06-g10_ehr_patient_launch_stu2-g10_patient_context: 9.9.10
+g10_certification-Group06-g10_ehr_patient_launch_stu2-g10_patient_scope: 9.9.11
 g10_certification-Group06-g10_visual_inspection_and_attestations: '9.10'
 g10_certification-Group06-g10_visual_inspection_and_attestations-Test01: 9.10.01
 g10_certification-Group06-g10_visual_inspection_and_attestations-Test02: 9.10.02

--- a/lib/onc_certification_g10_test_kit/smart_ehr_patient_launch_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_patient_launch_group.rb
@@ -1,17 +1,29 @@
+require_relative 'patient_scope_test'
+
 module ONCCertificationG10TestKit
   class SMARTEHRPatientLaunchGroup < SMARTAppLaunch::EHRLaunchGroup
     title 'EHR Launch with Patient Scopes'
     description %(
       # Background
+      Systems are required to support the `permission-patient` capability as
+      part of the [Clinician Access for EHR Launch Capability
+      Set.](http://hl7.org/fhir/smart-app-launch/1.0.0/conformance/index.html#clinician-access-for-ehr-launch)
 
-      If an application launched from an EHR requests and is granted a clinical
-      scope restricted to a single patient, the EHR SHALL establish a patient in
-      context.
+      Additionally, if an application launched from an EHR requests and is
+      granted a clinical scope restricted to a single patient, the EHR SHALL
+      establish a patient in context.
+
+      Register Inferno as an EHR-launched application using patient-level scopes
+      and the following URIs:
+
+      * Launch URI: `#{SMARTAppLaunch::AppLaunchTest.config.options[:launch_uri]}`
+      * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
 
       # Test Methodology
 
       Inferno will attempt an EHR Launch with a clinical scope restricted to a
-      single patient and verify that a patient id is received.
+      single patient and verify that a patient-level scope is granted and a
+      patient id is received.
 
       For more information on the #{title}
 
@@ -43,6 +55,9 @@ module ONCCertificationG10TestKit
         launch: {
           name: :ehr_patient_launch
         },
+        received_scopes: {
+          name: :ehr_patient_received_scopes
+        },
         smart_credentials: {
           name: :ehr_patient_smart_credentials
         },
@@ -67,6 +82,7 @@ module ONCCertificationG10TestKit
         patient_id: { name: :ehr_patient_patient_id },
         encounter_id: { name: :ehr_patient_encounter_id },
         received_scopes: { name: :ehr_patient_received_scopes },
+        requested_scopes: { name: :ehr_patient_requested_scopes },
         intent: { name: :ehr_patient_intent },
         smart_credentials: { name: :ehr_patient_smart_credentials }
       },
@@ -87,6 +103,13 @@ module ONCCertificationG10TestKit
            inputs: {
              patient_id: { name: :ehr_patient_patient_id },
              smart_credentials: { name: :ehr_patient_smart_credentials }
+           }
+         }
+
+    test from: :g10_patient_scope,
+         config: {
+           options: {
+             scope_version: :v1
            }
          }
   end

--- a/lib/onc_certification_g10_test_kit/smart_ehr_patient_launch_group_stu2.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_patient_launch_group_stu2.rb
@@ -1,17 +1,29 @@
+require_relative 'patient_scope_test'
+
 module ONCCertificationG10TestKit
   class SMARTEHRPatientLaunchGroupSTU2 < SMARTAppLaunch::EHRLaunchGroupSTU2
     title 'EHR Launch with Patient Scopes'
     description %(
       # Background
+      Systems are required to support the `permission-patient` capability as
+      part of the [Clinician Access for EHR Launch Capability
+      Set.](http://hl7.org/fhir/smart-app-launch/STU2/conformance.html#clinician-access-for-ehr-launch)
 
-      If an application launched from an EHR requests and is granted a clinical
-      scope restricted to a single patient, the EHR SHALL establish a patient in
-      context.
+      Additionally, if an application launched from an EHR requests and is
+      granted a clinical scope restricted to a single patient, the EHR SHALL
+      establish a patient in context.
+
+      Register Inferno as an EHR-launched application using patient-level scopes
+      and the following URIs:
+
+      * Launch URI: `#{SMARTAppLaunch::AppLaunchTest.config.options[:launch_uri]}`
+      * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
 
       # Test Methodology
 
       Inferno will attempt an EHR Launch with a clinical scope restricted to a
-      single patient and verify that a patient id is received.
+      single patient and verify that a patient-level scope is granted and a
+      patient id is received.
 
       For more information on the #{title}
 
@@ -43,6 +55,9 @@ module ONCCertificationG10TestKit
         launch: {
           name: :ehr_patient_launch
         },
+        received_scopes: {
+          name: :ehr_patient_received_scopes
+        },
         smart_credentials: {
           name: :ehr_patient_smart_credentials
         },
@@ -67,6 +82,7 @@ module ONCCertificationG10TestKit
         patient_id: { name: :ehr_patient_patient_id },
         encounter_id: { name: :ehr_patient_encounter_id },
         received_scopes: { name: :ehr_patient_received_scopes },
+        requested_scopes: { name: :ehr_patient_requested_scopes },
         intent: { name: :ehr_patient_intent },
         smart_credentials: { name: :ehr_patient_smart_credentials }
       },
@@ -88,6 +104,13 @@ module ONCCertificationG10TestKit
            inputs: {
              patient_id: { name: :ehr_patient_patient_id },
              smart_credentials: { name: :ehr_patient_smart_credentials }
+           }
+         }
+
+    test from: :g10_patient_scope,
+         config: {
+           options: {
+             scope_version: :v2
            }
          }
   end

--- a/spec/onc_certification_g10_test_kit/smart_ehr_patient_launch_group_spec.rb
+++ b/spec/onc_certification_g10_test_kit/smart_ehr_patient_launch_group_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe ONCCertificationG10TestKit::SMARTEHRPatientLaunchGroup do # rubocop:disable RSpec/FilePath
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(
+        test_session_id: test_session.id,
+        name: name,
+        value: value,
+        type: runnable.config.input_type(name) || 'text'
+      )
+    end
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+  end
+
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'g10_certification') }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test) do
+    described_class.tests.find { |test| test.id.to_s.end_with? 'g10_patient_scope' }
+  end
+
+  describe 'scopes test' do
+    it 'fails if patient-level scopes are not received' do
+      repo_create(:request, test_session_id: test_session.id, name: :ehr_patient_token, status: 200)
+      result =
+        run(
+          test,
+          ehr_patient_received_scopes: 'launch openid fhirUser offline_access user/Patient.read'
+        )
+
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(%r{patient/Patient\.read scope was requested, but not received.})
+    end
+
+    it 'passes if patient-level scopes are received' do
+      repo_create(:request, test_session_id: test_session.id, name: :ehr_patient_token, status: 200)
+      result =
+        run(
+          test,
+          ehr_patient_received_scopes: 'launch openid fhirUser offline_access patient/Patient.read'
+        )
+
+      expect(result.result).to eq('pass')
+    end
+  end
+end

--- a/spec/onc_certification_g10_test_kit/smart_ehr_patient_launch_group_spec.rb
+++ b/spec/onc_certification_g10_test_kit/smart_ehr_patient_launch_group_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe ONCCertificationG10TestKit::SMARTEHRPatientLaunchGroup do # ruboc
     inputs.each do |name, value|
       session_data_repo.save(
         test_session_id: test_session.id,
-        name: name,
-        value: value,
+        name:,
+        value:,
         type: runnable.config.input_type(name) || 'text'
       )
     end
-    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
   let(:test_session) { repo_create(:test_session, test_suite_id: 'g10_certification') }

--- a/spec/onc_certification_g10_test_kit/smart_ehr_patient_launch_group_stu2_spec.rb
+++ b/spec/onc_certification_g10_test_kit/smart_ehr_patient_launch_group_stu2_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe ONCCertificationG10TestKit::SMARTEHRPatientLaunchGroupSTU2 do # r
     inputs.each do |name, value|
       session_data_repo.save(
         test_session_id: test_session.id,
-        name: name,
-        value: value,
+        name:,
+        value:,
         type: runnable.config.input_type(name) || 'text'
       )
     end
-    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
   let(:test_session) { repo_create(:test_session, test_suite_id: 'g10_certification') }

--- a/spec/onc_certification_g10_test_kit/smart_ehr_patient_launch_group_stu2_spec.rb
+++ b/spec/onc_certification_g10_test_kit/smart_ehr_patient_launch_group_stu2_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe ONCCertificationG10TestKit::SMARTEHRPatientLaunchGroupSTU2 do # rubocop:disable RSpec/FilePath
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(
+        test_session_id: test_session.id,
+        name: name,
+        value: value,
+        type: runnable.config.input_type(name) || 'text'
+      )
+    end
+    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
+  end
+
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'g10_certification') }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test) do
+    described_class.tests.find { |test| test.id.to_s.end_with? 'g10_patient_scope' }
+  end
+
+  describe 'scopes test' do
+    it 'fails if patient-level scopes are not received' do
+      repo_create(:request, test_session_id: test_session.id, name: :ehr_patient_token, status: 200)
+      result =
+        run(
+          test,
+          ehr_patient_received_scopes: 'launch openid fhirUser offline_access user/Patient.rs'
+        )
+
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(%r{patient/Patient\.rs scope was requested, but not received.})
+    end
+
+    it 'passes if patient-level scopes are received' do
+      repo_create(:request, test_session_id: test_session.id, name: :ehr_patient_token, status: 200)
+      result =
+        run(
+          test,
+          ehr_patient_received_scopes: 'launch openid fhirUser offline_access patient/Patient.rs'
+        )
+
+      expect(result.result).to eq('pass')
+    end
+  end
+end


### PR DESCRIPTION
This branch adds tests to verify that patient-level scopes are received during the EHR Launch with Patient Scopes (see #330).