### PR TITLE
FI-1789: Add special case for us core 5 Condition.category terminology

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    onc_certification_g10_test_kit (3.3.0)
+    onc_certification_g10_test_kit (3.3.1.dev)
       bloomer (~> 1.0.0)
       colorize (~> 0.8.1)
       inferno_core (>= 0.4.2)

--- a/lib/onc_certification_g10_test_kit/terminology_binding_validator.rb
+++ b/lib/onc_certification_g10_test_kit/terminology_binding_validator.rb
@@ -44,8 +44,8 @@ module ONCCertificationG10TestKit
 
       error_message = %(
         #{resource_type}/#{resource.id} does not contain a `category` from the
-        #`http://hl7.org/fhir/us/core/ValueSet/us-core-problem-or-health-concern`
-        #ValueSet.
+        `http://hl7.org/fhir/us/core/ValueSet/us-core-problem-or-health-concern`
+        ValueSet.
       )
 
       validation_messages << {

--- a/lib/onc_certification_g10_test_kit/version.rb
+++ b/lib/onc_certification_g10_test_kit/version.rb
@@ -1,3 +1,3 @@
 module ONCCertificationG10TestKit
-  VERSION = '3.3.0'.freeze
+  VERSION = '3.3.1.dev'.freeze
 end


### PR DESCRIPTION
`Condition/260` on  inferno-dev has been updated to include the US Core 5 categories. The `Condition Problems and Health Concerns` tests will fail against inferno-dev on `main`, but should pass on this branch (see #340).