### PR TITLE
FI-1792 Terminology Validator handles binding with required binding slice

### DIFF
--- a/lib/onc_certification_g10_test_kit/terminology_binding_validator.rb
+++ b/lib/onc_certification_g10_test_kit/terminology_binding_validator.rb
@@ -37,11 +37,11 @@ module ONCCertificationG10TestKit
 
       return if valid_binding.present?
 
-      system = binding_definition[:system].presence || 'the declared CodeSystem'
+      system = binding_definition[:system].presence || 'the declared Value Set'
 
       error_message = %(
-        #{resource_type}/#{resource.id} at #{resource_type}.#{binding_definition[:path]} does not
-        contain a valid code from #{system} Value Set.
+        #{resource_type}/#{resource.id} at #{resource_type}.#{binding_definition[:path]}
+        does not contain a valid code from #{system}.
       )
 
       validation_messages << {

--- a/lib/onc_certification_g10_test_kit/terminology_binding_validator.rb
+++ b/lib/onc_certification_g10_test_kit/terminology_binding_validator.rb
@@ -18,11 +18,6 @@ module ONCCertificationG10TestKit
       @validation_messages = []
     end
 
-    def us_core_5_condition_category?
-      binding_definition[:path] == 'category' &&
-        binding_definition[:system] == 'http://hl7.org/fhir/us/core/ValueSet/us-core-problem-or-health-concern'
-    end
-
     def validate
       # Handle special case due to required binding on a slice
       if binding_definition[:required_binding_slice]

--- a/lib/onc_certification_g10_test_kit/terminology_binding_validator.rb
+++ b/lib/onc_certification_g10_test_kit/terminology_binding_validator.rb
@@ -25,8 +25,8 @@ module ONCCertificationG10TestKit
 
     def validate
       # Handle special case due to required binding on a slice
-      if us_core_5_condition_category?
-        validate_us_core_5_condition_category
+      if binding_definition[:required_binding_slice]
+        validate_required_binding_slice
       else
         add_error(element_with_invalid_binding) if element_with_invalid_binding.present? # rubocop:disable Style/IfInsideElse
       end
@@ -34,18 +34,19 @@ module ONCCertificationG10TestKit
       validation_messages
     end
 
-    def validate_us_core_5_condition_category
-      valid_category =
+    def validate_required_binding_slice
+      valid_binding =
         find_a_value_at(path_source, binding_definition[:path]) do |element|
           !invalid_binding?(element)
         end
 
-      return if valid_category.present?
+      return if valid_binding.present?
+
+      system = binding_definition[:system].presence || 'the declared CodeSystem'
 
       error_message = %(
-        #{resource_type}/#{resource.id} does not contain a `category` from the
-        `http://hl7.org/fhir/us/core/ValueSet/us-core-problem-or-health-concern`
-        ValueSet.
+        #{resource_type}/#{resource.id} at #{resource_type}.#{binding_definition[:path]} does not
+        contain a valid code from #{system} Value Set.
       )
 
       validation_messages << {

--- a/spec/onc_certification_g10_test_kit/terminology_binding_validator_spec.rb
+++ b/spec/onc_certification_g10_test_kit/terminology_binding_validator_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe ONCCertificationG10TestKit::TerminologyBindingValidator do
         expect(result.length).to eq(0)
       end
 
-      it 'fails when required_bidning_slice is not specified' do
+      it 'fails when required_binding_slice is not specified' do
         binding_definition.delete(:required_binding_slice)
         result = described_class.validate(resource, binding_definition)
 

--- a/spec/onc_certification_g10_test_kit/terminology_binding_validator_spec.rb
+++ b/spec/onc_certification_g10_test_kit/terminology_binding_validator_spec.rb
@@ -279,16 +279,17 @@ RSpec.describe ONCCertificationG10TestKit::TerminologyBindingValidator do
         expect(result).to be_an(Array)
         expect(result.length).to eq(1)
         expect(result.first[:message]).to include("does not contain a valid code from #{binding_definition[:system]}.")
-
       end
 
-      it 'fails resource with both required binding code and non required binding code when required_binding_slice is not specified' do
+      it 'fails resource with both when required_binding_slice is not specified' do
         binding_definition.delete(:required_binding_slice)
         result = described_class.validate(resource, binding_definition)
 
         expect(result).to be_an(Array)
         expect(result.length).to eq(1)
-        expect(result.first[:message]).to include("with code `#{system_url}|#{bad_code}` is not in #{binding_definition[:system]}.")
+        expect(result.first[:message]).to include(
+          "with code `#{system_url}|#{bad_code}` is not in #{binding_definition[:system]}."
+        )
       end
     end
   end

--- a/spec/onc_certification_g10_test_kit/terminology_binding_validator_spec.rb
+++ b/spec/onc_certification_g10_test_kit/terminology_binding_validator_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe ONCCertificationG10TestKit::TerminologyBindingValidator do
           id: '123',
           category: [
             {
-              'coding': [
+              coding: [
                 {
                   system: system_url,
                   code: good_code
@@ -237,7 +237,7 @@ RSpec.describe ONCCertificationG10TestKit::TerminologyBindingValidator do
               ]
             },
             {
-              'coding': [
+              coding: [
                 {
                   system: system_url,
                   code: bad_code

--- a/spec/onc_certification_g10_test_kit/terminology_binding_validator_spec.rb
+++ b/spec/onc_certification_g10_test_kit/terminology_binding_validator_spec.rb
@@ -272,12 +272,23 @@ RSpec.describe ONCCertificationG10TestKit::TerminologyBindingValidator do
         expect(result.length).to eq(0)
       end
 
-      it 'fails when required_binding_slice is not specified' do
+      it 'fails resource with non required binding code only' do
+        resource.category.delete_at(0)
+        result = described_class.validate(resource, binding_definition)
+
+        expect(result).to be_an(Array)
+        expect(result.length).to eq(1)
+        expect(result.first[:message]).to include("does not contain a valid code from #{binding_definition[:system]}.")
+
+      end
+
+      it 'fails resource with both required binding code and non required binding code when required_binding_slice is not specified' do
         binding_definition.delete(:required_binding_slice)
         result = described_class.validate(resource, binding_definition)
 
         expect(result).to be_an(Array)
         expect(result.length).to eq(1)
+        expect(result.first[:message]).to include("with code `#{system_url}|#{bad_code}` is not in #{binding_definition[:system]}.")
       end
     end
   end


### PR DESCRIPTION
This is part of fix for GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/361.

This PR relates to US Core Test Kit PR: https://github.com/inferno-framework/us-core-test-kit/pull/94

This PR changes:
* Replace the validate logic for us-core-5-condition with a more general logic for any binding in a mandatory slice with `required` binding strength
* Add unit test

Testing:
Verify all unit tests pass