### PR TITLE
FI-1670: Make patient id list optional for bulk data tests

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
@@ -17,11 +17,12 @@ module ONCCertificationG10TestKit
           optional: true
     input :bulk_patient_ids_in_group,
           title: 'Patient IDs in exported Group',
-          description: <<~DESCRIPTION
+          description: <<~DESCRIPTION,
             Comma separated list of every Patient ID that is in the specified Group. This information is provided by
             the system under test to verify that data returned matches expectations. Leave blank to not verify Group
             inclusion.
           DESCRIPTION
+          optional: true
     input :bulk_device_types_in_group,
           title: 'Implantable Device Type Codes in exported Group',
           description: <<~DESCRIPTION,


### PR DESCRIPTION
This branch fixes the patient id list input for bulk data so that it is now optional as stated in its description.