### PR TITLE
FI-1834: Allow multiple bulk profiles

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -107,6 +107,9 @@ module ONCCertificationG10TestKit
           perform_must_support_test(resources[meta.profile_url])
         rescue Inferno::Exceptions::PassException
           next
+        rescue Inferno::Exceptions::SkipException => e
+          e.message.concat " for `#{meta.profile_url}`"
+          raise e
         end
       end
     end

--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -124,7 +124,7 @@ module ONCCertificationG10TestKit
       line_count = 0
       resources = Hash.new { |h, k| h[k] = [] }
 
-      process_line = proc { |line|
+      process_line = proc do |line|
         next unless lines_to_validate.blank? ||
                     line_count < lines_to_validate.to_i ||
                     (resource_type == 'Patient' && patient_ids_seen.length < MIN_RESOURCE_COUNT)
@@ -142,21 +142,24 @@ module ONCCertificationG10TestKit
                         "defined in output \"#{resource_type}\""
         end
 
-        profile_url = determine_profile(resource)
-        resources[profile_url] << resource
-        scratch[:patient_ids_seen] = patient_ids_seen | [resource.id] if resource_type == 'Patient'
+        profile_urls = determine_profile(resource)
+        profile_urls.each do |profile_url|
+          resources[profile_url] << resource
 
-        profile_with_version = versioned_profile_url(profile_url)
-        unless resource_is_valid?(resource:, profile_url: profile_with_version)
-          if first_error.key?(:line_number)
-            @invalid_resource_count += 1
-          else
-            @invalid_resource_count = 1
-            first_error[:line_number] = line_count
-            first_error[:messages] = messages.dup
+          scratch[:patient_ids_seen] = patient_ids_seen | [resource.id] if resource_type == 'Patient'
+
+          profile_with_version = versioned_profile_url(profile_url)
+          unless resource_is_valid?(resource:, profile_url: profile_with_version)
+            if first_error.key?(:line_number)
+              @invalid_resource_count += 1
+            else
+              @invalid_resource_count = 1
+              first_error[:line_number] = line_count
+              first_error[:messages] = messages.dup
+            end
           end
         end
-      }
+      end
 
       process_headers = proc { |response|
         value = (response[:headers].find { |header| header.name.downcase == 'content-type' })&.value

--- a/lib/onc_certification_g10_test_kit/profile_selector.rb
+++ b/lib/onc_certification_g10_test_kit/profile_selector.rb
@@ -30,46 +30,50 @@ module ONCCertificationG10TestKit
     end
 
     def select_profile(resource) # rubocop:disable Metrics/CyclomaticComplexity
+      profiles = []
+
       case resource.resourceType
       when 'Condition'
         case us_core_version
         when US_CORE_5
           if resource_contains_category(resource, 'encounter-diagnosis', 'http://terminology.hl7.org/CodeSystem/condition-category')
-            extract_profile('ConditionEncounterDiagnosis')
+            profiles << extract_profile('ConditionEncounterDiagnosis')
           elsif resource_contains_category(resource, 'problem-list-item',
                                            'http://terminology.hl7.org/CodeSystem/condition-category') ||
                 resource_contains_category(resource, 'health-concern', 'http://hl7.org/fhir/us/core/CodeSystem/condition-category')
-            extract_profile('ConditionProblemsHealthConcerns')
+            profiles << extract_profile('ConditionProblemsHealthConcerns')
           end
         else
-          extract_profile(resource.resourceType)
+          profiles << extract_profile(resource.resourceType)
         end
       when 'DiagnosticReport'
-        return extract_profile('DiagnosticReportLab') if resource_contains_category(resource, 'LAB', 'http://terminology.hl7.org/CodeSystem/v2-0074')
-
-        extract_profile('DiagnosticReportNote')
+        profiles << if resource_contains_category(resource, 'LAB', 'http://terminology.hl7.org/CodeSystem/v2-0074')
+                      extract_profile('DiagnosticReportLab')
+                    else
+                      extract_profile('DiagnosticReportNote')
+                    end
       when 'Observation'
-        return extract_profile('Smokingstatus') if observation_contains_code(resource, '72166-2')
+        profiles << extract_profile('Smokingstatus') if observation_contains_code(resource, '72166-2')
 
-        return extract_profile('ObservationLab') if resource_contains_category(resource, 'laboratory', 'http://terminology.hl7.org/CodeSystem/observation-category')
+        profiles << extract_profile('ObservationLab') if resource_contains_category(resource, 'laboratory', 'http://terminology.hl7.org/CodeSystem/observation-category')
 
-        return extract_profile('PediatricBmiForAge') if observation_contains_code(resource, '59576-9')
+        profiles << extract_profile('PediatricBmiForAge') if observation_contains_code(resource, '59576-9')
 
-        return extract_profile('PediatricWeightForHeight') if observation_contains_code(resource, '77606-2')
+        profiles << extract_profile('PediatricWeightForHeight') if observation_contains_code(resource, '77606-2')
 
-        return extract_profile('PulseOximetry') if observation_contains_code(resource, '59408-5')
+        profiles << extract_profile('PulseOximetry') if observation_contains_code(resource, '59408-5')
 
         if observation_contains_code(resource, '8289-1')
-          case us_core_version
-          when US_CORE_3
-            return extract_profile('HeadCircumference')
-          else
-            return extract_profile('HeadCircumferencePercentile')
-          end
+          profiles << case us_core_version
+                      when US_CORE_3
+                        extract_profile('HeadCircumference')
+                      else
+                        extract_profile('HeadCircumferencePercentile')
+                      end
         end
 
         if observation_contains_code(resource, '9843-4') && !using_us_core_3?
-          return extract_profile('HeadCircumference')
+          profiles << extract_profile('HeadCircumference')
         end
 
         # FHIR Vital Signs profiles: https://www.hl7.org/fhir/observation-vitalsigns.html
@@ -77,83 +81,83 @@ module ONCCertificationG10TestKit
         # Body Mass Index is replaced by :pediatric_bmi_age Profile
         # Systolic Blood Pressure, Diastolic Blood Pressure are covered by :blood_pressure Profile
         # Head Circumference is replaced by US Core Head Occipital-frontal Circumference Percentile Profile
-        return extract_profile('Bmi') if observation_contains_code(resource, '39156-5') && !using_us_core_3?
+        profiles << extract_profile('Bmi') if observation_contains_code(resource, '39156-5') && !using_us_core_3?
 
         if observation_contains_code(resource, '85354-9')
-          case us_core_version
-          when US_CORE_3
-            return extract_profile('Bp')
-          else
-            return extract_profile('BloodPressure')
-          end
+          profiles << case us_core_version
+                      when US_CORE_3
+                        extract_profile('Bp')
+                      else
+                        extract_profile('BloodPressure')
+                      end
         end
 
         if observation_contains_code(resource, '8302-2')
-          case us_core_version
-          when US_CORE_3
-            return extract_profile('Bodyheight')
-          else
-            return extract_profile('BodyHeight')
-          end
+          profiles << case us_core_version
+                      when US_CORE_3
+                        extract_profile('Bodyheight')
+                      else
+                        extract_profile('BodyHeight')
+                      end
         end
 
         if observation_contains_code(resource, '8310-5')
-          case us_core_version
-          when US_CORE_3
-            return extract_profile('Bodytemp')
-          else
-            return extract_profile('BodyTemperature')
-          end
+          profiles << case us_core_version
+                      when US_CORE_3
+                        extract_profile('Bodytemp')
+                      else
+                        extract_profile('BodyTemperature')
+                      end
         end
 
         if observation_contains_code(resource, '29463-7')
-          case us_core_version
-          when US_CORE_3
-            return extract_profile('Bodyweight')
-          else
-            return extract_profile('BodyWeight')
-          end
+          profiles << case us_core_version
+                      when US_CORE_3
+                        extract_profile('Bodyweight')
+                      else
+                        extract_profile('BodyWeight')
+                      end
         end
 
         if observation_contains_code(resource, '8867-4')
-          case us_core_version
-          when US_CORE_3
-            return extract_profile('Heartrate')
-          else
-            return extract_profile('HeartRate')
-          end
+          profiles << case us_core_version
+                      when US_CORE_3
+                        extract_profile('Heartrate')
+                      else
+                        extract_profile('HeartRate')
+                      end
         end
 
         if observation_contains_code(resource, '9279-1')
-          case us_core_version
-          when US_CORE_3
-            return extract_profile('Resprate')
-          else
-            return extract_profile('RespiratoryRate')
-          end
+          profiles << case us_core_version
+                      when US_CORE_3
+                        extract_profile('Resprate')
+                      else
+                        extract_profile('RespiratoryRate')
+                      end
         end
 
         if using_us_core_5? &&
            resource_contains_category(
              resource, 'clinical-test', 'http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category'
            )
-          return extract_profile('ObservationClinicalTest')
+          profiles << extract_profile('ObservationClinicalTest')
         end
 
         if using_us_core_5? && observation_contains_code(resource, '76690-7')
-          return extract_profile('ObservationSexualOrientation')
+          profiles << extract_profile('ObservationSexualOrientation')
         end
 
         if using_us_core_5? &&
            resource_contains_category(resource, 'social-history',
                                       'http://terminology.hl7.org/CodeSystem/observation-category')
-          return extract_profile('ObservationSocialHistory')
+          profiles << extract_profile('ObservationSocialHistory')
         end
 
         if using_us_core_5? &&
            resource_contains_category(resource, 'imaging',
                                       'http://terminology.hl7.org/CodeSystem/observation-category')
-          return extract_profile('ObservationImaging')
+          profiles << extract_profile('ObservationImaging')
         end
 
         # We will simply match all Observations of category "survey" to SDOH,
@@ -171,13 +175,15 @@ module ONCCertificationG10TestKit
            resource_contains_category(resource, 'survey',
                                       'http://terminology.hl7.org/CodeSystem/observation-category')
 
-          return extract_profile('ObservationSdohAssessment')
+          profiles << extract_profile('ObservationSdohAssessment')
         end
 
         nil
       else
-        extract_profile(resource.resourceType)
+        profiles << extract_profile(resource.resourceType)
       end
+
+      profiles
     rescue StandardError
       skip "Could not determine profile of \"#{resource.resourceType}\" resource."
     end

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -144,8 +144,8 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
 
       expect(result.result).to eq('skip')
       expect(result.result_message)
-        .to eq('Could not find identifier, identifier.system, identifier.value ' \
-               'in the 2 provided Patient resource(s)')
+        .to start_with('Could not find identifier, identifier.system, identifier.value ' \
+                       'in the 2 provided Patient resource(s)')
     end
 
     it 'passes when returned resources are fully conformant to the patient profile' do
@@ -289,7 +289,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
 
       expect(result.result).to eq('skip')
       expect(result.result_message)
-        .to eq('Could not find clinicalStatus in the 10 provided AllergyIntolerance resource(s)')
+        .to start_with('Could not find clinicalStatus in the 10 provided AllergyIntolerance resource(s)')
     end
 
     it 'passes when returned resources are fully conformant to the allergy profile' do
@@ -338,7 +338,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
       result = run(runnable, careplan_input)
 
       expect(result.result).to eq('skip')
-      expect(result.result_message).to eq('Could not find text.status in the 26 provided CarePlan resource(s)')
+      expect(result.result_message).to start_with('Could not find text.status in the 26 provided CarePlan resource(s)')
     end
 
     it 'skips when returned resources are missing a must support slice' do
@@ -351,7 +351,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
 
       expect(result.result).to eq('skip')
       expect(result.result_message)
-        .to eq('Could not find CarePlan.category:AssessPlan in the 26 provided CarePlan resource(s)')
+        .to start_with('Could not find CarePlan.category:AssessPlan in the 26 provided CarePlan resource(s)')
     end
 
     it 'passes when returned resources are fully conformant to the patient profile' do
@@ -665,7 +665,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
 
       expect(result.result).to eq('skip')
       expect(result.result_message)
-        .to eq('Could not find code in the 1 provided Medication resource(s)')
+        .to start_with('Could not find code in the 1 provided Medication resource(s)')
     end
 
     it 'passes when the returned resources are fully conformant' do

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -423,7 +423,26 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
 
     context 'with Observation resource' do
       context 'when using US Core 5.0.1' do
-        it 'returns the SmokingStatus profile if resource has SmokingStatus criterion specified' do
+        it 'returns the SmokingStatus and Social History profiles for SmokingStatus resources' do
+          allow(tester).to receive(:suite_options).and_return({ us_core_version: 'us_core_5' })
+
+          coding = FHIR::Coding.new({ code: '72166-2' })
+          code = FHIR::CodeableConcept.new({ coding: [coding] })
+          FHIR::Observation.new({ code: })
+
+          category_coding = FHIR::Coding.new({ code: 'social-history',
+                                               system: 'http://terminology.hl7.org/CodeSystem/observation-category' })
+          category = FHIR::CodeableConcept.new({ coding: [category_coding] })
+          observation = FHIR::Observation.new({ category: [category], code: })
+
+          result = tester.determine_profile(observation)
+          expect(result).to match_array([
+                                          'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-social-history',
+                                          'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus'
+                                        ])
+        end
+
+        it 'returns the Observation Imaging profile when its criterion are specified' do
           allow(tester).to receive(:suite_options).and_return({ us_core_version: 'us_core_5' })
 
           coding = FHIR::Coding.new({ code: 'imaging',
@@ -444,6 +463,10 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
         end
 
         it 'returns the SmokingStatus profile if resource has SmokingStatus criterion specified' do
+          category_coding = FHIR::Coding.new({ code: 'social-history',
+                                               system: 'http://terminology.hl7.org/CodeSystem/observation-category' })
+          observation.category = [FHIR::CodeableConcept.new({ coding: [category_coding] })]
+
           result = tester.determine_profile(observation)
           expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus'])
         end

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
 
     it 'returns the vice profile if given a Device resource that is predefined' do
       result = tester.determine_profile(device_resource)
-      expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device')
+      expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device'])
     end
 
     it "skips if given resource's type is not defined" do
@@ -363,17 +363,17 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
 
     it "returns AllergyIntolerance's profile when given an AllergyIntolerance resource" do
       result = tester.determine_profile(FHIR::AllergyIntolerance.new)
-      expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance')
+      expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance'])
     end
 
     it "returns Location's profile when given a Location resource" do
       result = tester.determine_profile(FHIR::Location.new)
-      expect(result).to eq('http://hl7.org/fhir/StructureDefinition/Location')
+      expect(result).to eq(['http://hl7.org/fhir/StructureDefinition/Location'])
     end
 
     it "returns Medications's profile when given a Medication resource" do
       result = tester.determine_profile(FHIR::Medication.new)
-      expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication')
+      expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication'])
     end
 
     context 'with Condition resource' do
@@ -401,7 +401,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
         )
 
         result = tester.determine_profile(condition)
-        expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns')
+        expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns'])
       end
     end
 
@@ -412,12 +412,12 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
         diagnostic_report = FHIR::DiagnosticReport.new({ category: [category] })
 
         result = tester.determine_profile(diagnostic_report)
-        expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab')
+        expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab'])
       end
 
       it 'returns note profile if lab criterion unspecified' do
         result = tester.determine_profile(FHIR::DiagnosticReport.new)
-        expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note')
+        expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note'])
       end
     end
 
@@ -432,7 +432,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
           observation = FHIR::Observation.new({ category: [category] })
 
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-imaging')
+          expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-imaging'])
         end
       end
 
@@ -445,7 +445,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
 
         it 'returns the SmokingStatus profile if resource has SmokingStatus criterion specified' do
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus')
+          expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus'])
         end
 
         it 'returns the ObservationLab profile if resource has ObservationLab criterion specified' do
@@ -455,91 +455,91 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
           observation = FHIR::Observation.new({ category: [category] })
 
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab')
+          expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab'])
         end
 
         it 'returns the PediatricBmiForAge profile if resource has PediatricBmiForAge criterion specified' do
           observation.code.coding[0].code = '59576-9'
 
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age')
+          expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age'])
         end
 
         it 'returns the PediatricWeightForHeight profile if resource has PediatricWeightForHeight code' do
           observation.code.coding[0].code = '77606-2'
 
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height')
+          expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height'])
         end
 
         it 'returns the PulseOximetry profile if resource has PulseOximetry criterion specified' do
           observation.code.coding[0].code = '59408-5'
 
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry')
+          expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry'])
         end
 
         it 'returns the HeadCircumference profile if resource has HeadCircumference criterion specified' do
           observation.code.coding[0].code = '8289-1'
 
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile')
+          expect(result).to eq(['http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile'])
         end
 
         it 'returns the Bp profile if resource has Bp criterion specified' do
           observation.code.coding[0].code = '85354-9'
 
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/StructureDefinition/bp')
+          expect(result).to eq(['http://hl7.org/fhir/StructureDefinition/bp'])
         end
 
         it 'returns the Bodyheight profile if resource has Bodyheight criterion specified' do
           observation.code.coding[0].code = '8302-2'
 
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/StructureDefinition/bodyheight')
+          expect(result).to eq(['http://hl7.org/fhir/StructureDefinition/bodyheight'])
         end
 
         it 'returns the Bodytemp profile if resource has Bodytemp criterion specified' do
           observation.code.coding[0].code = '8310-5'
 
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/StructureDefinition/bodytemp')
+          expect(result).to eq(['http://hl7.org/fhir/StructureDefinition/bodytemp'])
         end
 
         it 'returns the Bodyweight profile if resource has Bodyweight criterion specified' do
           observation.code.coding[0].code = '29463-7'
 
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/StructureDefinition/bodyweight')
+          expect(result).to eq(['http://hl7.org/fhir/StructureDefinition/bodyweight'])
         end
 
         it 'returns the Heartrate profile if resource has Heartrate criterion specified' do
           observation.code.coding[0].code = '8867-4'
 
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/StructureDefinition/heartrate')
+          expect(result).to eq(['http://hl7.org/fhir/StructureDefinition/heartrate'])
         end
 
         it 'returns the Resprate profile if resource has Resprate criterion specified' do
           observation.code.coding[0].code = '9279-1'
 
           result = tester.determine_profile(observation)
-          expect(result).to eq('http://hl7.org/fhir/StructureDefinition/resprate')
+          expect(result).to eq(['http://hl7.org/fhir/StructureDefinition/resprate'])
         end
 
-        it 'returns nil when given none of the possible sets of profile criterion' do
+        it 'returns an empty array when given none of the possible sets of profile criterion' do
           observation.code.coding[0].code = 'bad_code'
 
           result = tester.determine_profile(observation)
-          expect(result).to be_nil
+          expect(result).to eq([])
         end
 
-        it 'returns nil when the Observation contains a head circumference code' do
+        it 'returns an empty array when the Observation contains a head circumference code' do
           observation.code.coding[0].code = '9843-4'
 
           result = tester.determine_profile(observation)
-          expect(result).to be_nil
+          expect(result).to eq([])
         end
       end
     end


### PR DESCRIPTION
This branch updates the profile selector used by bulk data to allow resources to match with multiple profiles (see #380). If you run the bulk data tests on `main` using US Core 5, the Observation test will fail because not all MS fields are found because most of the resources that could match one profile have instead been matched with another. The Observation bulk data tests should pass on this branch.