### PR TITLE
fi-1748 Adds attestation to ensure that systems are capable of extending authorized access of refresh tokens (Minor-version change)

### DIFF
--- a/lib/onc_certification_g10_test_kit/onc_program_procedure.yml
+++ b/lib/onc_certification_g10_test_kit/onc_program_procedure.yml
@@ -960,7 +960,7 @@ procedure:
           implementation specification adopted in § 170.215(a)(3).
         inferno_supported: 'yes'
         inferno_tests:
-          - 9.10.15
+          - 9.10.16
         inferno_notes: |
           Inferno cannot verify the three month token expiration requirement
           automatically during the token refresh tests, but the tester can

--- a/lib/onc_certification_g10_test_kit/onc_program_procedure.yml
+++ b/lib/onc_certification_g10_test_kit/onc_program_procedure.yml
@@ -960,7 +960,7 @@ procedure:
           implementation specification adopted in § 170.215(a)(3).
         inferno_supported: 'yes'
         inferno_tests:
-          - 9.10.05
+          - 9.10.15
         inferno_notes: |
           Inferno cannot verify the three month token expiration requirement
           automatically during the token refresh tests, but the tester can

--- a/lib/onc_certification_g10_test_kit/short_id_map.yml
+++ b/lib/onc_certification_g10_test_kit/short_id_map.yml
@@ -1536,3 +1536,4 @@ g10_certification-Group06-g10_visual_inspection_and_attestations-Test12: 9.10.12
 g10_certification-Group06-g10_visual_inspection_and_attestations-Test13: 9.10.13
 g10_certification-Group06-g10_visual_inspection_and_attestations-g10_public_url_attestation: 9.10.14
 g10_certification-Group06-g10_visual_inspection_and_attestations-g10_tls_version_attestation: 9.10.15
+g10_certification-Group06-g10_visual_inspection_and_attestations-g10_refresh_token_refresh_attestation: 9.10.16

--- a/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
+++ b/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
@@ -331,16 +331,16 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'Health IT developer confirms the Health IT module does not cache the JWK Set received ' \
+      title 'Health IT developer confirms the Health IT Module does not cache the JWK Set received ' \
             'via a TLS-protected URL for longer than the cache-control header received by an application indicates.'
       description %(
-        The Health IT developer confirms the Health IT module does not cache the
+        The Health IT developer confirms the Health IT Module does not cache the
         JWK Set received via a TLS-protected URL for longer than the
         cache-control header indicates.
       )
       id 'Test10'
       input :jwks_cache_attestation,
-            title: 'Health IT developer confirms the Health IT module does not cache the JWK Set received via a TLS-protected URL for longer than the cache-control header indicates.', # rubocop:disable Layout/LineLength
+            title: 'Health IT developer confirms the Health IT Module does not cache the JWK Set received via a TLS-protected URL for longer than the cache-control header indicates.', # rubocop:disable Layout/LineLength
             type: 'radio',
             default: 'false',
             options: {
@@ -577,32 +577,34 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'Health IT developer attested that the Health IT module is capable of issuing refresh tokens ' \
+      title 'Health IT developer attested that the Health IT Module is capable of issuing refresh tokens ' \
             'valid for a new period of no shorter than three months without requiring ' \
             're-authentication and re-authorization when a valid refresh token is supplied ' \
             'by the application.'
       description %(
-        Applications that are capable of protecting a client secret and that
-        have received a refresh token must be able to use this refresh token to
-        either receive a new refresh token valid for a new period of three
-        months, or to extend the duration of the existing refresh token for an
-        additional three months.  This occurs during the refresh token request,
-        when the application uses a refresh token to receive a new access token.
+        Applications that are capable of storing a client secret and that have
+        received a refresh token must be able to use this refresh token to
+        either receive a new refresh token valid for a new period of no less
+        than three months, or to update the duration of the existing refresh
+        token to be valid for a new period of no less than three months.  This
+        occurs during the refresh token request, when the application uses a
+        refresh token to receive a new access token.
 
         This attestation is necessary because automated tests cannot determine
-        if the expiration date of the refresh token is extended when tokens
+        if the expiration date of the refresh token is updated when tokens
         are refreshed.
 
-        This attestation ensures that the Health IT module allows applications
-        to use refresh tokens to extend the length of authorized access beyond
-        three months by issuing a new refresh token or extending the duration of
-        the existing refresh token.  A previous attestation ensures that the
-        Health IT module is capable of issuing an initial refresh token that is
-        valid for at least three months.
+        This attestation ensures that the Health IT Module allows applications
+        to use refresh tokens to update the length of authorized access beyond
+        the initial period of no less than three months by issuing a new refresh
+        token or updating the duration of the existing refresh token.  A
+        separate attestation ensures that the Health IT Module is capable of
+        issuing an initial refresh token that is valid for at least three
+        months.
       )
       id :g10_refresh_token_refresh_attestation
       input :refresh_token_refresh_attestation,
-            title: 'Health IT developer attested that the Health IT module is capable of issuing refresh tokens ' \
+            title: 'Health IT developer attested that the Health IT Module is capable of issuing refresh tokens ' \
                    'valid for a new period of no shorter than three months without requiring ' \
                    're-authentication and re-authorization when a valid refresh token is supplied ' \
                    'by the application.',
@@ -627,7 +629,7 @@ module ONCCertificationG10TestKit
 
       run do
         assert refresh_token_refresh_attestation == 'true',
-               'Health IT developer did not attest that the Health IT module is capable of issuing refresh tokens ' \
+               'Health IT developer did not attest that the Health IT Module is capable of issuing refresh tokens ' \
                'valid for a new period of no shorter than three months without requiring ' \
                're-authentication and re-authorization when a valid refresh token is supplied ' \
                'by the application.'

--- a/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
+++ b/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
@@ -579,7 +579,7 @@ module ONCCertificationG10TestKit
     test do
       title 'Health IT developer attested that the Health IT module is capable of issuing refresh tokens ' \
             'valid for a new period of no shorter than three months without requiring ' \
-            're-authentication and re-authorization when a valid refresh token is supplied '\
+            're-authentication and re-authorization when a valid refresh token is supplied ' \
             'by the application.'
       description %(
         Applications that are capable of protecting a client secret and that
@@ -603,9 +603,9 @@ module ONCCertificationG10TestKit
       id :g10_refresh_token_refresh_attestation
       input :refresh_token_refresh_attestation,
             title: 'Health IT developer attested that the Health IT module is capable of issuing refresh tokens ' \
-              'valid for a new period of no shorter than three months without requiring ' \
-              're-authentication and re-authorization when a valid refresh token is supplied '\
-              'by the application.',
+                   'valid for a new period of no shorter than three months without requiring ' \
+                   're-authentication and re-authorization when a valid refresh token is supplied ' \
+                   'by the application.',
             type: 'radio',
             default: 'false',
             options: {
@@ -627,10 +627,10 @@ module ONCCertificationG10TestKit
 
       run do
         assert refresh_token_refresh_attestation == 'true',
-              'Health IT developer did not attest that the Health IT module is capable of issuing refresh tokens ' \
-              'valid for a new period of no shorter than three months without requiring ' \
-              're-authentication and re-authorization when a valid refresh token is supplied '\
-              'by the application.'
+               'Health IT developer did not attest that the Health IT module is capable of issuing refresh tokens ' \
+               'valid for a new period of no shorter than three months without requiring ' \
+               're-authentication and re-authorization when a valid refresh token is supplied ' \
+               'by the application.'
 
         pass refresh_token_refresh_notes if refresh_token_refresh_notes.present?
       end

--- a/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
+++ b/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
@@ -155,6 +155,9 @@ module ONCCertificationG10TestKit
       description %(
         Health IT Module attested that it is capable of issuing refresh tokens
         that are valid for a period of no shorter than three months.
+
+        This attestation is necessary because automated tests cannot determine how long
+        the refresh token remains valid.
       )
       id 'Test05'
       input :refresh_token_period_attestation,
@@ -490,7 +493,7 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'Health IT developer demonstrates the public location of its base URLs'
+      title 'Health IT developer demonstrates the public location of its base URLs.'
       description %(
         To fulfill the API Maintenance of Certification requirement at §
         170.404(b)(2), the health IT developer demonstrates the public location
@@ -542,7 +545,7 @@ module ONCCertificationG10TestKit
             locked: true,
             optional: true
       input :tls_documentation_required,
-            title: 'Health IT developers must document how the Health IT Module enforces TLs version 1.2 or above',
+            title: 'Health IT developers must document how the Health IT Module enforces TLs version 1.2 or above.',
             type: 'radio',
             default: 'false',
             locked: true,
@@ -570,6 +573,66 @@ module ONCCertificationG10TestKit
         end
 
         pass tls_version_attestation_notes if tls_version_attestation_notes.present?
+      end
+    end
+
+    test do
+      title 'Health IT developer attested that the Health IT module is capable of issuing refresh tokens ' \
+            'valid for a new period of no shorter than three months without requiring ' \
+            're-authentication and re-authorization when a valid refresh token is supplied '\
+            'by the application.'
+      description %(
+        Applications that are capable of protecting a client secret and that
+        have received a refresh token must be able to use this refresh token to
+        either receive a new refresh token valid for a new period of three
+        months, or to extend the duration of the existing refresh token for an
+        additional three months.  This occurs during the refresh token request,
+        when the application uses a refresh token to receive a new access token.
+
+        This attestation is necessary because automated tests cannot determine
+        if the expiration date of the refresh token is extended when tokens
+        are refreshed.
+
+        This attestation ensures that the Health IT module allows applications
+        to use refresh tokens to extend the length of authorized access beyond
+        three months by issuing a new refresh token or extending the duration of
+        the existing refresh token.  A previous attestation ensures that the
+        Health IT module is capable of issuing an initial refresh token that is
+        valid for at least three months.
+      )
+      id :g10_refresh_token_refresh_attestation
+      input :refresh_token_refresh_attestation,
+            title: 'Health IT developer attested that the Health IT module is capable of issuing refresh tokens ' \
+              'valid for a new period of no shorter than three months without requiring ' \
+              're-authentication and re-authorization when a valid refresh token is supplied '\
+              'by the application.',
+            type: 'radio',
+            default: 'false',
+            options: {
+              list_options: [
+                {
+                  label: 'Yes',
+                  value: 'true'
+                },
+                {
+                  label: 'No',
+                  value: 'false'
+                }
+              ]
+            }
+      input :refresh_token_refresh_notes,
+            title: 'Notes, if applicable:',
+            type: 'textarea',
+            optional: true
+
+      run do
+        assert refresh_token_refresh_attestation == 'true',
+              'Health IT developer did not attest that the Health IT module is capable of issuing refresh tokens ' \
+              'valid for a new period of no shorter than three months without requiring ' \
+              're-authentication and re-authorization when a valid refresh token is supplied '\
+              'by the application.'
+
+        pass refresh_token_refresh_notes if refresh_token_refresh_notes.present?
       end
     end
   end


### PR DESCRIPTION
Adds attestation regarding extending the life of refresh tokens. I based the language of the attestation from the test procedure, and provide more details in the 'About' section.

<img width="913" alt="Screen Shot 2023-01-04 at 9 22 09 PM" src="https://user-images.githubusercontent.com/412901/210687794-9dc6e220-26ea-40c1-8855-e8834da99295.png">

Language from the test procedure:

> AUT-PAT-22: The health IT developer demonstrates the ability of the Health IT Module to issue a refresh token valid for a new period of no shorter than three months without requiring re-authentication and re-authorization when a valid refresh token is supplied by the application according to the implementation specification adopted in § 170.215(a)(3).

I felt like it would be useful to mention that this is different than the refresh token duration attestation in the  'about' section, as I figured that would be a common question.  That one is:

> 9.10.05 Health IT Module attested that it is capable of issuing refresh tokens that are valid for a period of no shorter than three months. 

Relevant github ticket: https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/382


