### PR TITLE
FI-1765: Check status of cancelled bulk export (Minor Version Change)

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_stu1.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_stu1.rb
@@ -286,9 +286,13 @@ module ONCCertificationG10TestKit
 
       include ExportKickOffPerformer
 
+      output :cancelled_polling_url
+
       run do
         perform_export_kick_off_request
         assert_response_status(202)
+
+        output cancelled_polling_url: request.response_header('content-location')&.value
 
         delete_export_kick_off_request
       end

--- a/lib/onc_certification_g10_test_kit/onc_program_procedure.yml
+++ b/lib/onc_certification_g10_test_kit/onc_program_procedure.yml
@@ -2186,6 +2186,7 @@ procedure:
         inferno_tests:
           - 7.2.07
           - 8.2.07
+          - 8.2.09
       - id: DAT-PAT-13
         SUT: |
           The health IT developer demonstrates the ability of the Health IT

--- a/lib/onc_certification_g10_test_kit/short_id_map.yml
+++ b/lib/onc_certification_g10_test_kit/short_id_map.yml
@@ -1414,6 +1414,7 @@ g10_certification-multi_patient_api_stu2-bulk_data_group_export_stu2-Test05: 8.2
 g10_certification-multi_patient_api_stu2-bulk_data_group_export_stu2-Test06: 8.2.06
 g10_certification-multi_patient_api_stu2-bulk_data_group_export_stu2-Test07: 8.2.07
 g10_certification-multi_patient_api_stu2-bulk_data_group_export_stu2-output_format_in_export_response: 8.2.08
+g10_certification-multi_patient_api_stu2-bulk_data_group_export_stu2-bulk_data_poll_cancelled_export: 8.2.09
 g10_certification-multi_patient_api_stu2-g10_bulk_group_export_tls_messages_setup: '8.02'
 g10_certification-multi_patient_api_stu2-bulk_data_group_export_validation: '8.3'
 g10_certification-multi_patient_api_stu2-bulk_data_group_export_validation-g10_bulk_file_server_tls_version: 8.3.01

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_stu2_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_stu2_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportSTU2 do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  describe '[Bulk Data Server supports "_outputFormat" query parameter] test' do
-    let(:runnable) { group.tests.last }
+  describe 'Bulk Data Server supports "_outputFormat" query parameter test' do
+    let(:runnable) { group.tests.find { |test| test.id.to_s.end_with? 'output_format_in_export_response' } }
     let(:long_format_req) do
       stub_request(:get, "#{export_url}?_outputFormat=application%2Ffhir%2Bndjson")
         .to_return(status: 202, headers: { 'Content-Location' => polling_url })
@@ -110,6 +110,41 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportSTU2 do
 
       expect(result.result).to eq('pass')
       expect(delete_export_req).to have_been_made.at_least_times(3)
+    end
+  end
+
+  describe 'Status of cancelled export test' do
+    let(:runnable) { group.tests.find { |test| test.id.to_s.end_with? 'bulk_data_poll_cancelled_export' } }
+    let(:url) { 'http://example.com' }
+
+    it 'fails if a 404 is not received' do
+      stub_request(:get, url)
+        .to_return(status: 202)
+
+      result = run(runnable, cancelled_polling_url: url)
+
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/404/)
+    end
+
+    it 'fails if an OperationOutcome is not received' do
+      stub_request(:get, url)
+        .to_return(status: 404, body: '{}')
+
+      result = run(runnable, cancelled_polling_url: url)
+
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/OperationOutcome/)
+    end
+
+    it 'passes if a 404 and valid OperationOutcome are received' do
+      stub_request(:get, url)
+        .to_return(status: 404, body: FHIR::OperationOutcome.new.to_json)
+      allow_any_instance_of(runnable).to receive(:assert_valid_resource).and_return(true)
+
+      result = run(runnable, cancelled_polling_url: url)
+
+      expect(result.result).to eq('pass')
     end
   end
 end


### PR DESCRIPTION
Bulk data v2 requires specific behavior for status requests for cancelled bulk exports (see #385).