### PR TITLE
FI-1868: Validate granted scope types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,7 @@ GEM
     puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.2)
-    rack (2.2.5)
+    rack (2.2.6.2)
     rainbow (3.1.1)
     rake (13.0.6)
     redis (4.8.0)

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -138,13 +138,10 @@ module ONCCertificationG10TestKit
           },
           options: {
             scope_version: :v1,
-            required_scope_type: 'user'
+            required_scope_type: 'user',
+            required_scopes: ['openid', 'fhirUser', 'launch', 'offline_access']
           }
         )
-
-        def required_scopes
-          ['openid', 'fhirUser', 'launch', 'offline_access']
-        end
       end
 
       test from: :g10_unauthorized_access,
@@ -287,13 +284,10 @@ module ONCCertificationG10TestKit
           },
           options: {
             scope_version: :v2,
-            required_scope_type: 'user'
+            required_scope_type: 'user',
+            required_scopes: ['openid', 'fhirUser', 'launch', 'offline_access']
           }
         )
-
-        def required_scopes
-          ['openid', 'fhirUser', 'launch', 'offline_access']
-        end
       end
 
       test from: :g10_unauthorized_access,

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -137,16 +137,13 @@ module ONCCertificationG10TestKit
             received_scopes: { name: :ehr_received_scopes }
           },
           options: {
-            scope_version: :v1
+            scope_version: :v1,
+            required_scope_type: 'user'
           }
         )
 
         def required_scopes
           ['openid', 'fhirUser', 'launch', 'offline_access']
-        end
-
-        def required_scope_type
-          'user'
         end
       end
 
@@ -289,16 +286,13 @@ module ONCCertificationG10TestKit
             received_scopes: { name: :ehr_received_scopes }
           },
           options: {
-            scope_version: :v2
+            scope_version: :v2,
+            required_scope_type: 'user'
           }
         )
 
         def required_scopes
           ['openid', 'fhirUser', 'launch', 'offline_access']
-        end
-
-        def required_scope_type
-          'user'
         end
       end
 

--- a/lib/onc_certification_g10_test_kit/smart_scopes_test.rb
+++ b/lib/onc_certification_g10_test_kit/smart_scopes_test.rb
@@ -79,6 +79,10 @@ module ONCCertificationG10TestKit
       config.options[:required_scope_type]
     end
 
+    def required_scopes
+      config.options[:required_scopes]
+    end
+
     def read_format
       @read_format ||=
         begin

--- a/lib/onc_certification_g10_test_kit/smart_scopes_test.rb
+++ b/lib/onc_certification_g10_test_kit/smart_scopes_test.rb
@@ -75,6 +75,10 @@ module ONCCertificationG10TestKit
       V5_VALID_RESOURCE_TYPES
     end
 
+    def required_scope_type
+      config.options[:required_scope_type]
+    end
+
     def read_format
       @read_format ||=
         begin

--- a/lib/onc_certification_g10_test_kit/smart_scopes_test.rb
+++ b/lib/onc_certification_g10_test_kit/smart_scopes_test.rb
@@ -187,6 +187,8 @@ module ONCCertificationG10TestKit
         resource_type, access_level = resource_scope_parts
         next unless access_level =~ access_level_regex
 
+        next unless ['patient', 'user', 'system'].include?(scope_type)
+
         assert_correct_scope_type(scope, scope_type, resource_type)
 
         granted_resource_types << resource_type

--- a/lib/onc_certification_g10_test_kit/smart_scopes_test.rb
+++ b/lib/onc_certification_g10_test_kit/smart_scopes_test.rb
@@ -83,13 +83,17 @@ module ONCCertificationG10TestKit
       config.options[:required_scopes]
     end
 
+    def scope_version
+      config.options[:scope_version]
+    end
+
     def read_format
       @read_format ||=
         begin
           v1_read_format = 'read'
           v2_read_format = 'c?ru?d?s?'
 
-          case config.options[:scope_version]
+          case scope_version
           when :v1
             "#{v1_read_format} | *"
           when :v2
@@ -102,13 +106,13 @@ module ONCCertificationG10TestKit
 
     def access_level_regex
       @access_level_regex ||=
-        case config.options[:scope_version]
+        case scope_version
         when :v1
-          /\A(\*|read)/
+          /\A(\*|read)\b/
         when :v2
-          /\A(\*|c?ru?d?s?\b)/
+          /\A(\*|c?ru?d?s?)\b/
         else
-          /\A(\*|read|c?ru?d?s?\b)/
+          /\A(\*|read|c?ru?d?s?)\b/
         end
     end
 
@@ -120,41 +124,45 @@ module ONCCertificationG10TestKit
     end
 
     def strip_experimental_scope_syntax(full_scope)
-      if config.options[:scope_version] == :v1
+      if scope_version == :v1
         full_scope
       else
         full_scope.split('?').first
       end
     end
 
-    def requested_scope_test(scopes, patient_compartment_resource_types)
+    def assert_correct_scope_type(scope, scope_type, resource_type)
+      if required_scope_type == 'patient' && patient_compartment_resource_types.exclude?(resource_type)
+        assert ['user', 'patient'].include?(scope_type),
+               "Requested scope '#{scope}' must begin with either 'user/' or 'patient/'"
+      else
+        assert scope_type == required_scope_type, bad_format_message(scope)
+      end
+    end
+
+    def requested_scope_test(scopes)
       correct_scope_type_found = false
 
       scopes.each do |full_scope|
         scope = strip_experimental_scope_syntax(full_scope)
 
         scope_pieces = scope.split('/')
-        assert scope_pieces.count == 2, bad_format_message(scope)
+        assert scope_pieces.length == 2, bad_format_message(scope)
 
         scope_type, resource_scope = scope_pieces
-        resource_scope_parts = resource_scope.split('.')
 
+        resource_scope_parts = resource_scope.split('.')
         assert resource_scope_parts.length == 2, bad_format_message(scope)
 
         resource_type, access_level = resource_scope_parts
-        bad_resource_message = "'#{resource_type}' must be either a valid resource type or '*'"
-
-        if required_scope_type == 'patient' && patient_compartment_resource_types.exclude?(resource_type)
-          assert ['user', 'patient'].include?(scope_type),
-                 "Requested scope '#{scope}' must begin with either 'user/' or 'patient/'"
-        else
-          assert scope_type == required_scope_type, bad_format_message(scope)
-        end
-
-        assert valid_resource_types.include?(resource_type), bad_resource_message
         assert access_level =~ access_level_regex, bad_format_message(scope)
 
-        correct_scope_type_found = true
+        assert_correct_scope_type(scope, scope_type, resource_type)
+
+        assert valid_resource_types.include?(resource_type),
+               "'#{resource_type}' must be either a permitted resource type or '*'"
+
+        correct_scope_type_found = true if scope_type == required_scope_type
       end
 
       assert correct_scope_type_found,
@@ -162,22 +170,26 @@ module ONCCertificationG10TestKit
              "`#{required_scope_type}/[ <ResourceType> | * ].[ #{read_format} ]` was not requested."
     end
 
-    def received_scope_test(scopes, patient_compartment_resource_types)
+    def received_scope_test(scopes)
       granted_resource_types = []
 
       scopes.each do |full_scope|
         scope = strip_experimental_scope_syntax(full_scope)
 
         scope_pieces = scope.split('/')
-        next unless scope_pieces.count == 2
+        next unless scope_pieces.length == 2
 
-        _scope_type, resource_scope = scope_pieces
+        scope_type, resource_scope = scope_pieces
 
         resource_scope_parts = resource_scope.split('.')
-        next unless resource_scope_parts.count == 2
+        next unless resource_scope_parts.length == 2
 
         resource_type, access_level = resource_scope_parts
-        granted_resource_types << resource_type if access_level =~ access_level_regex
+        next unless access_level =~ access_level_regex
+
+        assert_correct_scope_type(scope, scope_type, resource_type)
+
+        granted_resource_types << resource_type
       end
 
       missing_resource_types =
@@ -217,12 +229,12 @@ module ONCCertificationG10TestKit
         # 'launch/patient' for EHR launch and Standalone launch.
         # 'launch/encounter' is mentioned by SMART App Launch though not in
         # (g)(10) test procedure
-        scopes -= ['online_access', 'launch', 'launch/patient', 'launch/encounter']
+        scopes -= ['online_access', 'offline_access', 'launch', 'launch/patient', 'launch/encounter']
 
         if received_or_requested == 'requested'
-          requested_scope_test(scopes, patient_compartment_resource_types)
+          requested_scope_test(scopes)
         else
-          received_scope_test(scopes, patient_compartment_resource_types)
+          received_scope_test(scopes)
         end
       end
     end

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -151,16 +151,13 @@ module ONCCertificationG10TestKit
             received_scopes: { name: :standalone_received_scopes }
           },
           options: {
-            scope_version: :v1
+            scope_version: :v1,
+            required_scope_type: 'patient'
           }
         )
 
         def required_scopes
           ['openid', 'fhirUser', 'launch/patient', 'offline_access']
-        end
-
-        def required_scope_type
-          'patient'
         end
       end
 
@@ -267,16 +264,13 @@ module ONCCertificationG10TestKit
             received_scopes: { name: :standalone_received_scopes }
           },
           options: {
-            scope_version: :v2
+            scope_version: :v2,
+            required_scope_type: 'patient'
           }
         )
 
         def required_scopes
           ['openid', 'fhirUser', 'launch/patient', 'offline_access']
-        end
-
-        def required_scope_type
-          'patient'
         end
       end
 

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -152,13 +152,10 @@ module ONCCertificationG10TestKit
           },
           options: {
             scope_version: :v1,
-            required_scope_type: 'patient'
+            required_scope_type: 'patient',
+            required_scopes: ['openid', 'fhirUser', 'launch/patient', 'offline_access']
           }
         )
-
-        def required_scopes
-          ['openid', 'fhirUser', 'launch/patient', 'offline_access']
-        end
       end
 
       test from: :g10_unauthorized_access,
@@ -265,13 +262,10 @@ module ONCCertificationG10TestKit
           },
           options: {
             scope_version: :v2,
-            required_scope_type: 'patient'
+            required_scope_type: 'patient',
+            required_scopes: ['openid', 'fhirUser', 'launch/patient', 'offline_access']
           }
         )
-
-        def required_scopes
-          ['openid', 'fhirUser', 'launch/patient', 'offline_access']
-        end
       end
 
       test from: :g10_unauthorized_access,

--- a/spec/onc_certification_g10_test_kit/smart_scopes_test_spec.rb
+++ b/spec/onc_certification_g10_test_kit/smart_scopes_test_spec.rb
@@ -1,0 +1,158 @@
+RSpec.describe ONCCertificationG10TestKit::SMARTScopesTest do
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(
+        test_session_id: test_session.id,
+        name:,
+        value:,
+        type: runnable.config.input_type(name)
+      )
+    end
+    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
+  end
+
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'g10_certification') }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test) { described_class }
+  let(:base_scopes) { 'offline_access launch' }
+
+  before do
+    repo_create(:request, test_session_id: test_session.id, name: :token)
+    allow_any_instance_of(test).to receive(:required_scopes).and_return(base_scopes.split)
+  end
+
+  context 'with patient-level scopes' do
+    before do
+      allow_any_instance_of(test).to receive(:required_scope_type).and_return('patient')
+    end
+
+    context 'with requested scopes' do
+      it 'fails if a required scope was not requested' do
+        result = run(test, requested_scopes: 'online_access launch')
+
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to eq('Required scopes were not requested: offline_access')
+      end
+
+      it 'fails if a scope has an invalid format' do
+        ['patient/*/read', 'patient*.read', 'patient/*.*.read', 'patient/*.readx'].each do |bad_scope|
+          result = run(test, requested_scopes: "#{base_scopes} #{bad_scope}")
+
+          expect(result.result).to eq('fail')
+          expect(result.result_message).to match('does not follow the format')
+          expect(result.result_message).to include(bad_scope)
+        end
+      end
+
+      it 'fails if a patient compartment resource has a user-level scope' do
+        bad_scope = 'user/Patient.read'
+        result = run(test, requested_scopes: "#{base_scopes} user/Binary.read #{bad_scope}")
+
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match('does not follow the format')
+        expect(result.result_message).to include(bad_scope)
+      end
+
+      it 'fails if a scope for a disallowed resource type is requested' do
+        bad_scope = 'patient/CodeSystem.read'
+        result = run(test, requested_scopes: "#{base_scopes} #{bad_scope}")
+
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match('must be either a permitted resource type')
+        expect(result.result_message).to include('CodeSystem')
+      end
+
+      it 'fails if no patient-level scopes were requested' do
+        result = run(test, requested_scopes: "#{base_scopes} user/Binary.read")
+
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match('Patient-level scope in the format')
+      end
+    end
+
+    context 'with v1 scopes' do
+      it 'fails if v2 scopes are requested' do
+        allow_any_instance_of(test).to receive(:scope_version).and_return(:v1)
+
+        bad_scope = 'patient/Patient.r'
+        result = run(test, requested_scopes: "#{base_scopes} user/Binary.read #{bad_scope}")
+
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match('does not follow the format')
+        expect(result.result_message).to include(bad_scope)
+      end
+    end
+
+    context 'with v2 scopes' do
+      it 'fails if v1 scopes are requested' do
+        allow_any_instance_of(test).to receive(:scope_version).and_return(:v2)
+
+        bad_scope = 'patient/Patient.read'
+        result = run(test, requested_scopes: "#{base_scopes} user/Binary.rs #{bad_scope}")
+
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match('does not follow the format')
+        expect(result.result_message).to include(bad_scope)
+      end
+    end
+
+    context 'with received scopes' do
+      let(:requested_scopes) { "#{base_scopes} patient/Patient.read" }
+
+      it 'fails if a patient compartment resource has a user-level scope' do
+        bad_scope = 'user/Patient.read'
+        result = run(test, requested_scopes:, received_scopes: "#{base_scopes} user/Binary.read #{bad_scope}")
+
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match('does not follow the format')
+        expect(result.result_message).to include(bad_scope)
+      end
+
+      it 'fails if the received scopes do not grant access to all required resource types' do
+        result = run(test, requested_scopes:, received_scopes: "#{base_scopes} patient/Patient.read")
+
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match('were not granted by authorization server')
+      end
+    end
+  end
+
+  context 'with user-level scopes' do
+    before do
+      allow_any_instance_of(test).to receive(:required_scope_type).and_return('user')
+    end
+
+    context 'with requested scopes' do
+      it 'fails if a patient-level scope is requested' do
+        bad_scope = 'patient/Patient.read'
+        result = run(test, requested_scopes: "#{base_scopes} user/Binary.read #{bad_scope}")
+
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match('does not follow the format')
+        expect(result.result_message).to include(bad_scope)
+      end
+
+      it 'fails if no user-level scopes were requested' do
+        result = run(test, requested_scopes: base_scopes)
+
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match('User-level scope in the format')
+      end
+    end
+
+    context 'with received scopes' do
+      let(:requested_scopes) { "#{base_scopes} patient/Patient.read" }
+
+      it 'fails if a patient-level scope is received' do
+        bad_scope = 'patient/Patient.read'
+        result = run(test, requested_scopes:, received_scopes: "#{base_scopes} user/Binary.read #{bad_scope}")
+
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match('does not follow the format')
+        expect(result.result_message).to include(bad_scope)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This branch updates the scope validation test to also validate that patient/user-level scopes are received rather than only validating that those scopes are requested (see #333).