### PR TITLE
FI-1869: Fix smart IG links in EHR launch with patient scopes

### DIFF
--- a/lib/onc_certification_g10_test_kit/patient_scope_test.rb
+++ b/lib/onc_certification_g10_test_kit/patient_scope_test.rb
@@ -3,11 +3,15 @@ module ONCCertificationG10TestKit
     title 'Patient-level scopes were granted'
     description %(
       Systems are required to support the `permission-patient` capability as
-      part of the [Clinician Access for EHR Launch Capability
-      Set.](http://hl7.org/fhir/smart-app-launch/1.0.0/conformance/index.html#clinician-access-for-ehr-launch)
+      part of the Clinician Access for EHR Launch Capability Set.
 
       This test verifies that systems are capable of granting patient-level
       scopes during an EHR Launch.
+
+      * [Clinician Access for EHR Launch Capability Set STU
+        1](http://hl7.org/fhir/smart-app-launch/1.0.0/conformance/index.html#clinician-access-for-ehr-launch)
+      * [Clinician Access for EHR Launch Capability Set STU
+        2](http://hl7.org/fhir/smart-app-launch/STU2/conformance.html#clinician-access-for-ehr-launch)
     )
     id :g10_patient_scope
     input :received_scopes

--- a/lib/onc_certification_g10_test_kit/smart_ehr_patient_launch_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_patient_launch_group.rb
@@ -28,7 +28,7 @@ module ONCCertificationG10TestKit
       For more information on the #{title}
 
       * [Apps that launch from the
-        EHR](http://hl7.org/fhir/smart-app-launch/STU2/scopes-and-launch-context.html#apps-that-launch-from-the-ehr)
+        EHR](http://hl7.org/fhir/smart-app-launch/1.0.0/scopes-and-launch-context/index.html#apps-that-launch-from-the-ehr)
     )
     id :g10_ehr_patient_launch
     run_as_group


### PR DESCRIPTION
Some links in the EHR Launch with Patient Scopes Group went to the incorrect IG version (see #389).