### PR TITLE
FI-1875: Suppress Limited App missing scope warnings for SMART STU 2

### DIFF
--- a/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
@@ -241,6 +241,7 @@ module ONCCertificationG10TestKit
           token: { name: :limited_token }
         },
         options: {
+          ignore_missing_scopes_check: true,
           redirect_message_proc: lambda do |auth_url|
             expected_resource_string =
               expected_resources


### PR DESCRIPTION
The limited app test is generating a warning when requested scopes are denied in STU 2, even though that is the expected behavior of the test (see #392). This branch corrects the configuration so that the warning will no longer appear.