### PR TITLE
FI-1959 Update Bulk time out skip message

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_stu1.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_stu1.rb
@@ -219,7 +219,9 @@ module ONCCertificationG10TestKit
         end
 
         if response[:status] == 202
-          skip "Server already used #{used_time} seconds processing this request, and next poll is #{wait_time} seconds after. The total wait time for next poll is more than #{timeout} seconds time out setting."
+          skip "Server already used #{used_time} seconds processing this request, " \
+               "and next poll is #{wait_time} seconds after. " \
+               "The total wait time for next poll is more than #{timeout} seconds time out setting."
         end
 
         assert_response_status(200)

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_stu1.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_stu1.rb
@@ -200,6 +200,7 @@ module ONCCertificationG10TestKit
 
         wait_time = 1
         start = Time.now
+        used_time = 0
 
         loop do
           get(polling_url, headers: { authorization: "Bearer #{bearer_token}", accept: 'application/json' })
@@ -208,14 +209,19 @@ module ONCCertificationG10TestKit
 
           wait_time = retry_after_val.positive? ? retry_after_val : wait_time *= 2
 
-          seconds_used = Time.now - start + wait_time
+          used_time = Time.now - start
 
-          break if response[:status] != 202 || seconds_used > timeout
+          total_time_to_next_poll = Time.now - start + wait_time
+
+          break if response[:status] != 202 || total_time_to_next_poll > timeout
 
           sleep wait_time
         end
 
-        skip "Server took more than #{timeout} seconds to process the request." if response[:status] == 202
+        if response[:status] == 202
+          skip "Server already used #{used_time} seconds processing this request, and next poll is #{wait_time} seconds after. The total wait time for next poll is more than #{timeout} seconds time out setting."
+        end
+
         assert_response_status(200)
 
         assert request.response_header('content-type')&.value&.include?('application/json'),

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_stu1_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_stu1_spec.rb
@@ -234,13 +234,15 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportSTU1 do
         .with(headers: { 'Authorization' => "Bearer #{bearer_token}" })
         .to_return(status: 202)
 
+      regex = /^#{"Server already used \\d+(\\.\\d+)? seconds processing this request, " \
+        "and next poll is \\d+ seconds after. " \
+        "The total wait time for next poll is more than \\d+ seconds time out setting."}$/
+
       allow_any_instance_of(runnable).to receive(:sleep)
       result = run(runnable, input)
 
       expect(result.result).to eq('skip')
-      expect(result.result_message).to match(
-        /^Server already used \d+(\.\d+)? seconds processing this request, and next poll is \d+ seconds after. The total wait time for next poll is more than \d+ seconds time out setting.$/
-      )
+      expect(result.result_message).to match(regex)
     end
 
     it 'fails when server does not return "202 Accepted" nor "200 OK' do

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_stu1_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_stu1_spec.rb
@@ -238,7 +238,9 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportSTU1 do
       result = run(runnable, input)
 
       expect(result.result).to eq('skip')
-      expect(result.result_message).to eq('Server took more than 180 seconds to process the request.')
+      expect(result.result_message).to match(
+        /^Server already used \d+(\.\d+)? seconds processing this request, and next poll is \d+ seconds after. The total wait time for next poll is more than \d+ seconds time out setting.$/
+      )
     end
 
     it 'fails when server does not return "202 Accepted" nor "200 OK' do


### PR DESCRIPTION
This PR fixes GitHub Issue #420 

What changed:
Update Bulk Data export timeout skip message to include: time used, next poll time, timeout setting.