### PR TITLE
FI-1946: Add version-specific validators

### DIFF
--- a/config/presets/inferno_reference_server_preset.json
+++ b/config/presets/inferno_reference_server_preset.json
@@ -746,31 +746,6 @@
       "value": null
     },
     {
-      "name": "patient_previous_name_attestation",
-      "type": "radio",
-      "title": "Health IT developer demonstrates support for the Patient Demographics Previous Name USCDI v1 element.",
-      "options": {
-        "list_options": [
-          {
-            "label": "Yes",
-            "value": "true"
-          },
-          {
-            "label": "No",
-            "value": "false"
-          }
-        ]
-      },
-      "value": "false"
-    },
-    {
-      "name": "patient_previous_name_notes",
-      "type": "textarea",
-      "title": "Notes, if applicable:",
-      "optional": true,
-      "value": null
-    },
-    {
       "name": "native_refresh_attestation",
       "type": "radio",
       "title": "Health IT developer demonstrates support for issuing refresh tokens to native applications.",

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -70,7 +70,7 @@ module ONCCertificationG10TestKit
         url ENV.fetch('G10_VALIDATOR_URL', 'http://validator_service:4567')
 
         us_core_message_filters =
-          case(us_core_version_requirement[:us_core_version])
+          case (us_core_version_requirement[:us_core_version])
           when G10Options::US_CORE_3
             USCoreTestKit::USCoreV311::USCoreTestSuite::VALIDATION_MESSAGE_FILTERS
           when G10Options::US_CORE_4
@@ -81,15 +81,17 @@ module ONCCertificationG10TestKit
 
         exclude_message do |message|
           if message.type == 'info' ||
-            (message.type == 'warning' && WARNING_INCLUSION_FILTERS.none? { |filter| filter.match? message.message }) ||
-            us_core_message_filters.any? { |filter| filter.match? message.message } ||
-            (
-              message.type == 'error' && (
-                message.message.match?(/\A\S+: \S+: Unknown Code/) ||
-                message.message.match?(/\A\S+: \S+: None of the codings provided are in the value set/) ||
-                message.message.match?(/\A\S+: \S+: The Coding provided \(\S*\) is not in the value set/)
-              )
-            )
+             (message.type == 'warning' && WARNING_INCLUSION_FILTERS.none? do |filter|
+                filter.match? message.message
+              end) ||
+             us_core_message_filters.any? { |filter| filter.match? message.message } ||
+             (
+               message.type == 'error' && (
+                 message.message.match?(/\A\S+: \S+: Unknown Code/) ||
+                 message.message.match?(/\A\S+: \S+: None of the codings provided are in the value set/) ||
+                 message.message.match?(/\A\S+: \S+: The Coding provided \(\S*\) is not in the value set/)
+               )
+             )
             true
           else
             false


### PR DESCRIPTION
This branch updates the g10 suite to use a different validator based on the US Core version.

You can test this by adding `puts us_core_version_requirement` inside the `perform_additional_validation` block. Then run some tests which perform validation, and you'll see output like `{:us_core_version=>"us_core_5"}` depending on which version you selected.