### PR TITLE
Minor Visual Fixes

### DIFF
--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -291,7 +291,9 @@ module ONCCertificationG10TestKit
           [Follow this link to authorize with the SMART server](#{auth_url}).
 
           Tests will resume once Inferno receives a request at
-          `#{config.options[:redirect_uri]}` with a state of `#{state}`.
+          `#{config.options[:redirect_uri]}`  
+          with a state of  
+          `#{state}`.
         )
       end
 

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -285,18 +285,14 @@ module ONCCertificationG10TestKit
       )
 
       default_redirect_message_proc = lambda do |auth_url|
-        # rubocop:disable Layout/TrailingWhitespace
         %(
           ### #{self.class.parent.title}
 
           [Follow this link to authorize with the SMART server](#{auth_url}).
 
           Tests will resume once Inferno receives a request at
-          `#{config.options[:redirect_uri]}`  
-          with a state of  
-          `#{state}`.
+          `#{config.options[:redirect_uri]}` with a state of `#{state}`.
         )
-        # rubocop:enable Layout/TrailingWhitespace
       end
 
       group from: :g10_public_standalone_launch,

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -240,7 +240,7 @@ module ONCCertificationG10TestKit
       Systems may adopt later versions of standards than those named in the rule
       as approved by the ONC Standards Version Advancement Process (SVAP).
       Please select which approved version of each standard to use, and click
-      ‘Select Options’ to begin testing.
+      ‘Start Testing’ to begin testing.
     )
 
     input_instructions %(

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -285,6 +285,7 @@ module ONCCertificationG10TestKit
       )
 
       default_redirect_message_proc = lambda do |auth_url|
+        # rubocop:disable Layout/TrailingWhitespace
         %(
           ### #{self.class.parent.title}
 
@@ -295,6 +296,7 @@ module ONCCertificationG10TestKit
           with a state of  
           `#{state}`.
         )
+        # rubocop:enable Layout/TrailingWhitespace
       end
 
       group from: :g10_public_standalone_launch,

--- a/lib/onc_certification_g10_test_kit/smart_invalid_pkce_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_invalid_pkce_group.rb
@@ -199,7 +199,9 @@ module ONCCertificationG10TestKit
                 server](#{auth_url}).
 
                   Tests will resume once Inferno receives a request at
-                  `#{config.options[:redirect_uri]}` with a state of `#{state}`.
+                  `#{config.options[:redirect_uri]}`  
+                  with a state of  
+                  #{state}`.
                )
              end
            }
@@ -226,7 +228,9 @@ module ONCCertificationG10TestKit
                 server](#{auth_url}).
 
                   Tests will resume once Inferno receives a request at
-                  `#{config.options[:redirect_uri]}` with a state of `#{state}`.
+                  `#{config.options[:redirect_uri]}`  
+                  with a state of  
+                  `#{state}`.
                )
              end
            }
@@ -257,7 +261,9 @@ module ONCCertificationG10TestKit
                 server](#{auth_url}).
 
                   Tests will resume once Inferno receives a request at
-                  `#{config.options[:redirect_uri]}` with a state of `#{state}`.
+                  `#{config.options[:redirect_uri]}`  
+                  with a state of  
+                  `#{state}`.
                )
              end
            }
@@ -288,8 +294,10 @@ module ONCCertificationG10TestKit
                 [Follow this link to authorize with the SMART
                 server](#{auth_url}).
 
-                  Tests will resume once Inferno receives a request at
-                  `#{config.options[:redirect_uri]}` with a state of `#{state}`.
+                Tests will resume once Inferno receives a request at
+                `#{config.options[:redirect_uri]}`  
+                with a state of  
+                `#{state}`.
                )
              end
            }

--- a/lib/onc_certification_g10_test_kit/smart_invalid_pkce_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_invalid_pkce_group.rb
@@ -189,7 +189,6 @@ module ONCCertificationG10TestKit
          config: {
            options: {
              redirect_message_proc: lambda do |auth_url|
-               # rubocop:disable Layout/TrailingWhitespace
                %(
                 ### Invalid PKCE code_verifier 1/4
 
@@ -200,11 +199,8 @@ module ONCCertificationG10TestKit
                 server](#{auth_url}).
 
                   Tests will resume once Inferno receives a request at
-                  `#{config.options[:redirect_uri]}`  
-                  with a state of  
-                  #{state}`.
+                  `#{config.options[:redirect_uri]}` with a state of #{state}`.
                )
-               # rubocop:enable Layout/TrailingWhitespace
              end
            }
          }
@@ -220,7 +216,6 @@ module ONCCertificationG10TestKit
          config: {
            options: {
              redirect_message_proc: lambda do |auth_url|
-               # rubocop:disable Layout/TrailingWhitespace
                %(
                 ### Invalid PKCE code_verifier 2/4
 
@@ -231,11 +226,8 @@ module ONCCertificationG10TestKit
                 server](#{auth_url}).
 
                   Tests will resume once Inferno receives a request at
-                  `#{config.options[:redirect_uri]}`  
-                  with a state of  
-                  `#{state}`.
+                  `#{config.options[:redirect_uri]}` with a state of `#{state}`.
                )
-               # rubocop:enable Layout/TrailingWhitespace
              end
            }
          }
@@ -255,7 +247,6 @@ module ONCCertificationG10TestKit
          config: {
            options: {
              redirect_message_proc: lambda do |auth_url|
-               # rubocop:disable Layout/TrailingWhitespace
                %(
                 ### Invalid PKCE code_verifier 3/4
 
@@ -266,11 +257,8 @@ module ONCCertificationG10TestKit
                 server](#{auth_url}).
 
                   Tests will resume once Inferno receives a request at
-                  `#{config.options[:redirect_uri]}`  
-                  with a state of  
-                  `#{state}`.
+                  `#{config.options[:redirect_uri]}` with a state of `#{state}`.
                )
-               # rubocop:enable Layout/TrailingWhitespace
              end
            }
          }
@@ -290,7 +278,6 @@ module ONCCertificationG10TestKit
          config: {
            options: {
              redirect_message_proc: lambda do |auth_url|
-               # rubocop:disable Layout/TrailingWhitespace
                %(
                 ### Invalid PKCE code_verifier 4/4
 
@@ -302,11 +289,8 @@ module ONCCertificationG10TestKit
                 server](#{auth_url}).
 
                 Tests will resume once Inferno receives a request at
-                `#{config.options[:redirect_uri]}`  
-                with a state of  
-                `#{state}`.
+                `#{config.options[:redirect_uri]}` with a state of `#{state}`.
                )
-               # rubocop:enable Layout/TrailingWhitespace
              end
            }
          }

--- a/lib/onc_certification_g10_test_kit/smart_invalid_pkce_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_invalid_pkce_group.rb
@@ -199,7 +199,7 @@ module ONCCertificationG10TestKit
                 server](#{auth_url}).
 
                   Tests will resume once Inferno receives a request at
-                  `#{config.options[:redirect_uri]}` with a state of #{state}`.
+                  `#{config.options[:redirect_uri]}` with a state of `#{state}`.
                )
              end
            }
@@ -288,8 +288,8 @@ module ONCCertificationG10TestKit
                 [Follow this link to authorize with the SMART
                 server](#{auth_url}).
 
-                Tests will resume once Inferno receives a request at
-                `#{config.options[:redirect_uri]}` with a state of `#{state}`.
+                  Tests will resume once Inferno receives a request at
+                  `#{config.options[:redirect_uri]}` with a state of `#{state}`.
                )
              end
            }

--- a/lib/onc_certification_g10_test_kit/smart_invalid_pkce_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_invalid_pkce_group.rb
@@ -189,6 +189,7 @@ module ONCCertificationG10TestKit
          config: {
            options: {
              redirect_message_proc: lambda do |auth_url|
+               # rubocop:disable Layout/TrailingWhitespace
                %(
                 ### Invalid PKCE code_verifier 1/4
 
@@ -203,6 +204,7 @@ module ONCCertificationG10TestKit
                   with a state of  
                   #{state}`.
                )
+               # rubocop:enable Layout/TrailingWhitespace
              end
            }
          }
@@ -218,6 +220,7 @@ module ONCCertificationG10TestKit
          config: {
            options: {
              redirect_message_proc: lambda do |auth_url|
+               # rubocop:disable Layout/TrailingWhitespace
                %(
                 ### Invalid PKCE code_verifier 2/4
 
@@ -232,6 +235,7 @@ module ONCCertificationG10TestKit
                   with a state of  
                   `#{state}`.
                )
+               # rubocop:enable Layout/TrailingWhitespace
              end
            }
          }
@@ -251,6 +255,7 @@ module ONCCertificationG10TestKit
          config: {
            options: {
              redirect_message_proc: lambda do |auth_url|
+               # rubocop:disable Layout/TrailingWhitespace
                %(
                 ### Invalid PKCE code_verifier 3/4
 
@@ -265,6 +270,7 @@ module ONCCertificationG10TestKit
                   with a state of  
                   `#{state}`.
                )
+               # rubocop:enable Layout/TrailingWhitespace
              end
            }
          }
@@ -284,6 +290,7 @@ module ONCCertificationG10TestKit
          config: {
            options: {
              redirect_message_proc: lambda do |auth_url|
+               # rubocop:disable Layout/TrailingWhitespace
                %(
                 ### Invalid PKCE code_verifier 4/4
 
@@ -299,6 +306,7 @@ module ONCCertificationG10TestKit
                 with a state of  
                 `#{state}`.
                )
+               # rubocop:enable Layout/TrailingWhitespace
              end
            }
          }

--- a/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
@@ -126,7 +126,7 @@ module ONCCertificationG10TestKit
                 .map(&:strip)
                 .map { |resource_type| "* #{resource_type}\n" }
                 .join
-
+            # rubocop:disable Layout/TrailingWhitespace
             <<~MESSAGE
               ### #{self.class.parent.parent.title}
 
@@ -142,6 +142,7 @@ module ONCCertificationG10TestKit
 
               #{expected_resource_string}
             MESSAGE
+            # rubocop:enable Layout/TrailingWhitespace
           end
         }
       )
@@ -251,7 +252,7 @@ module ONCCertificationG10TestKit
                 .map(&:strip)
                 .map { |resource_type| "* #{resource_type}\n" }
                 .join
-
+            # rubocop:disable Layout/TrailingWhitespace
             <<~MESSAGE
               ### #{self.class.parent.parent.title}
 
@@ -267,6 +268,7 @@ module ONCCertificationG10TestKit
 
               #{expected_resource_string}
             MESSAGE
+            # rubocop:enable Layout/TrailingWhitespace
           end
         }
       )

--- a/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
@@ -126,7 +126,7 @@ module ONCCertificationG10TestKit
                 .map(&:strip)
                 .map { |resource_type| "* #{resource_type}\n" }
                 .join
-            # rubocop:disable Layout/TrailingWhitespace
+
             <<~MESSAGE
               ### #{self.class.parent.parent.title}
 
@@ -134,15 +134,12 @@ module ONCCertificationG10TestKit
               server](#{auth_url}).
 
               Tests will resume once Inferno receives a request at
-              `#{config.options[:redirect_uri]}`  
-              with a state of  
-              `#{state}`.
+              `#{config.options[:redirect_uri]}` with a state of `#{state}`.
 
               Access should only be granted to the following resources:
 
               #{expected_resource_string}
             MESSAGE
-            # rubocop:enable Layout/TrailingWhitespace
           end
         }
       )
@@ -252,7 +249,7 @@ module ONCCertificationG10TestKit
                 .map(&:strip)
                 .map { |resource_type| "* #{resource_type}\n" }
                 .join
-            # rubocop:disable Layout/TrailingWhitespace
+
             <<~MESSAGE
               ### #{self.class.parent.parent.title}
 
@@ -260,15 +257,12 @@ module ONCCertificationG10TestKit
               server](#{auth_url}).
 
               Tests will resume once Inferno receives a request at
-              `#{config.options[:redirect_uri]}`  
-              with a state of  
-              `#{state}`.
+              `#{config.options[:redirect_uri]}` with a state of `#{state}`.
 
               Access should only be granted to the following resources:
 
               #{expected_resource_string}
             MESSAGE
-            # rubocop:enable Layout/TrailingWhitespace
           end
         }
       )

--- a/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
@@ -25,7 +25,7 @@ module ONCCertificationG10TestKit
       to the app based on user input. The tester is expected to grant the
       application access to a subset of desired resource types. The launch is
       performed using the same app configuration as in the Standalone Patient
-      App test, demonstrating that the user is control over what scopes are
+      App test, demonstrating that the user has control over what scopes are
       granted to the app as required in the (g)(10) Standardized API criterion.
 
       * [SMART on FHIR

--- a/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
@@ -134,7 +134,9 @@ module ONCCertificationG10TestKit
               server](#{auth_url}).
 
               Tests will resume once Inferno receives a request at
-              `#{config.options[:redirect_uri]}` with a state of `#{state}`.
+              `#{config.options[:redirect_uri]}`  
+              with a state of  
+              `#{state}`.
 
               Access should only be granted to the following resources:
 
@@ -257,7 +259,9 @@ module ONCCertificationG10TestKit
               server](#{auth_url}).
 
               Tests will resume once Inferno receives a request at
-              `#{config.options[:redirect_uri]}` with a state of `#{state}`.
+              `#{config.options[:redirect_uri]}`  
+              with a state of  
+              `#{state}`.
 
               Access should only be granted to the following resources:
 

--- a/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group.rb
@@ -1,6 +1,6 @@
 module ONCCertificationG10TestKit
   class SMARTPublicStandaloneLaunchGroup < SMARTAppLaunch::StandaloneLaunchGroup
-    title 'Public Client Standalone Launch with OpenID Connect'
+    title 'SMART Public Client Standalone Launch with OpenID Connect'
     short_title 'SMART Public Client Launch'
     input_instructions %(
       Register Inferno as a standalone application using the following information:

--- a/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group_stu2.rb
+++ b/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group_stu2.rb
@@ -1,6 +1,6 @@
 module ONCCertificationG10TestKit
   class SMARTPublicStandaloneLaunchGroupSTU2 < SMARTAppLaunch::StandaloneLaunchGroupSTU2
-    title 'Public Client Standalone Launch with OpenID Connect'
+    title 'SMART Public Client Standalone Launch with OpenID Connect'
     short_title 'SMART Public Client Launch'
     input_instructions %(
       Register Inferno as a standalone application using the following information:


### PR DESCRIPTION
JIRA Ticket: https://oncprojectracking.healthit.gov/support/browse/FI-2011

To Test:

- Review the [Walkthrough](https://github.com/onc-healthit/onc-certification-g10-test-kit/wiki/Walkthrough#inferno-g10-standardized-api-test-kit-walkthrough) to check that the changes stated in the ticket are accurately reflected.
- On the (g)(10) test kit option page, check that the last sentence of the text on the left says "click 'Start Testing' to begin testing"
- In Additional Tests, the long name of "SMART Public Client Launch" should now be "SMART Public Client Standalone Launch with OpenID Connect"
- For the "User Action Required" modal that pops up during the "Limited Access App" tests, the modal should now display with extra spacing like the image below, to improve readability.
<img width="614" alt="Screenshot 2023-07-07 at 3 42 49 PM" src="https://github.com/onc-healthit/onc-certification-g10-test-kit/assets/54954141/0d93badb-2fea-4e23-b849-903a9dd8b11f">

**Question**: Do you like the change to the modal, and if so, should I make a follow up ticket to change the other modals across test kits to match this?
