### PR TITLE
FI-1223: Support the validator /version returning a JSON

### DIFF
--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -41,6 +41,11 @@ module ONCCertificationG10TestKit
           message: "Expected FHIR validator version `#{EXPECTED_VALIDATOR_VERSION}`, but found `#{version}`"
         }]
       end
+    rescue JSON::ParserError => e
+      [{
+        type: 'error',
+        message: "Unable to parse Validator version '`#{response.body}`'. Parser error: `#{e.message}`"
+      }]
     rescue StandardError => e
       [{
         type: 'error',

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -22,7 +22,13 @@ module ONCCertificationG10TestKit
 
     def validator_version_message
       response = Faraday.get "#{validator_url}/version"
-      version = response.body
+
+      if response.body.starts_with? "{"
+        version_json = JSON.parse(response.body)
+        version = version_json["inferno-framework/fhir-validator-wrapper"]
+      else
+        version = response.body
+      end
 
       if version == EXPECTED_VALIDATOR_VERSION
         [{

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -23,9 +23,9 @@ module ONCCertificationG10TestKit
     def validator_version_message
       response = Faraday.get "#{validator_url}/version"
 
-      if response.body.starts_with? "{"
+      if response.body.starts_with? '{'
         version_json = JSON.parse(response.body)
-        version = version_json["inferno-framework/fhir-validator-wrapper"]
+        version = version_json['inferno-framework/fhir-validator-wrapper']
       else
         version = response.body
       end


### PR DESCRIPTION
In anticipation of the validator `/version` endpoint returning a JSON (see https://github.com/inferno-framework/fhir-validator-wrapper/pull/62 ), this PR updates the logic for checking the validator version.

Because previously the version check was just a basic string comparison, using JSON introduces some new ways it could fail: the JSON might not parse, or it might not contain the right key, etc. This set of changes is intended to be simple and minimal but not break if anything goes wrong. 

**Testing Guidance**:
Make sure an "old" instance of the validator that returns a string version doesn't crash. Make sure when using a validator returning JSON that this compares the version number against the value of the `inferno-framework/fhir-validator-wrapper` key as expected.