### PR TITLE
FI-1995: Changes for HL7 validator v6.0.21

### DIFF
--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -4,6 +4,7 @@ services:
     image: infernocommunity/fhir-validator-service:v2.2.1
     environment:
       - DISABLE_TX= true
+      - DISPLAY_ISSUES_ARE_WARNINGS=true
     volumes:
       - ./lib/onc_certification_g10_test_kit/igs:/home/igs
   # fhir_validator_app:

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   validator_service:
-    image: infernocommunity/fhir-validator-service:v2.2.1
+    image: infernocommunity/fhir-validator-service:v2.3.0
     environment:
       - DISABLE_TX= true
       - DISPLAY_ISSUES_ARE_WARNINGS=true

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -89,6 +89,7 @@ module ONCCertificationG10TestKit
                message.type == 'error' && (
                  message.message.match?(/\A\S+: \S+: Unknown Code/) ||
                  message.message.match?(/\A\S+: \S+: None of the codings provided are in the value set/) ||
+                 message.message.match?(/\A\S+: \S+: The code provided \(\S*\) is not in the value set/) ||
                  message.message.match?(/\A\S+: \S+: The Coding provided \(\S*\) is not in the value set/)
                )
              )

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -2,7 +2,7 @@ require_relative '../inferno/terminology/tasks/check_built_terminology'
 
 module ONCCertificationG10TestKit
   class ConfigurationChecker
-    EXPECTED_VALIDATOR_VERSION = '2.2.1'.freeze
+    EXPECTED_VALIDATOR_VERSION = '2.3.0'.freeze
 
     def configuration_messages
       validator_version_message + terminology_messages + version_message


### PR DESCRIPTION
The validator wrapper is being upgraded to use the most recent version of the HL7 validator (6.0.21 as of now, see https://github.com/inferno-framework/fhir-validator-wrapper/pull/61), and that version of the validator produces some slightly different output compared to the version we previously used (5.6.93):

1. Code displays that do not match the official display are now errors by default. This can be changed to match the old behavior with the environment variable "DISPLAY_ISSUES_ARE_WARNINGS" set to true. 

2. There's now an error message received when testing US Core 3.1.1 related to a constraint that cannot be met due to a bad profile, see message below. This was seen previously with slightly different text ( https://chat.fhir.org/#narrow/stream/179309-inferno/topic/Pulse.20Oximetry.20Flow.20Rate.20units )

> Observation/313: Observation.component[0].value.ofType(Quantity): The code provided ([http://unitsofmeasure.org#L/min](http://unitsofmeasure.org/#L/min)) is not in the value set 'Vital Signs Units' (http://hl7.org/fhir/ValueSet/ucum-vitals-common%7C4.0.1), and a code from this value set is required: Unable to check whether the code is in the value set http://hl7.org/fhir/ValueSet/ucum-vitals-common%7C4.0.1

Because we're already ignoring/excluding certain validator messages I added this one to that list.



~This is marked as draft until we tag & release a new version of the validator wrapper. (Though technically these should be backwards compatible in the sense that nothing will happen if the environment variable is set on a library that doesn't support it, and ignoring the error message shouldn't have any unexpected effects either)~

**Testing Guidance:**
Run the test suites against the inferno reference server and pointing to an updated version of the validator: https://github.com/inferno-framework/fhir-validator-wrapper/pull/61
Ensure all tests pass