### PR TITLE
Bump Validator dependency to v2.3.1

### DIFF
--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   validator_service:
-    image: infernocommunity/fhir-validator-service:v2.3.0
+    image: infernocommunity/fhir-validator-service:v2.3.1
     environment:
       - DISABLE_TX= true
       - DISPLAY_ISSUES_ARE_WARNINGS=true

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -2,7 +2,7 @@ require_relative '../inferno/terminology/tasks/check_built_terminology'
 
 module ONCCertificationG10TestKit
   class ConfigurationChecker
-    EXPECTED_VALIDATOR_VERSION = '2.3.0'.freeze
+    EXPECTED_VALIDATOR_VERSION = '2.3.1'.freeze
 
     def configuration_messages
       validator_version_message + terminology_messages + version_message


### PR DESCRIPTION
Bumps the Validator dependency to release v2.3.1. 

2.3.1 sorts the IGs it loads to ensure a consistent order, and ensures the `/version` endpoint is always accessible, so no changes to the interfaces and no other changes are required here.