### PR TITLE
select jwk by kid

### DIFF
--- a/lib/onc_certification_g10_test_kit/authorization_request_builder.rb
+++ b/lib/onc_certification_g10_test_kit/authorization_request_builder.rb
@@ -12,7 +12,7 @@ module ONCCertificationG10TestKit
     end
 
     attr_reader :encryption_method, :scope, :iss, :sub, :aud, :content_type, :grant_type, :client_assertion_type, :exp,
-                :jti
+                :jti, :kid
 
     def initialize(
       encryption_method:,
@@ -24,7 +24,8 @@ module ONCCertificationG10TestKit
       grant_type: 'client_credentials',
       client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
       exp: 5.minutes.from_now,
-      jti: SecureRandom.hex(32)
+      jti: SecureRandom.hex(32),
+      kid:
     )
       @encryption_method = encryption_method
       @scope = scope
@@ -36,13 +37,15 @@ module ONCCertificationG10TestKit
       @client_assertion_type = client_assertion_type
       @exp = exp
       @jti = jti
+      @kid = kid
     end
 
     def bulk_private_key
       @bulk_private_key ||=
         self.class.bulk_data_jwks['keys']
           .select { |key| key['key_ops']&.include?('sign') }
-          .find { |key| key['alg'] == encryption_method }
+          .select { |key| key['alg'] == encryption_method }
+          .find { |key| !kid || key['kid'] == kid }
     end
 
     def jwt_token

--- a/lib/onc_certification_g10_test_kit/authorization_request_builder.rb
+++ b/lib/onc_certification_g10_test_kit/authorization_request_builder.rb
@@ -25,7 +25,7 @@ module ONCCertificationG10TestKit
       client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
       exp: 5.minutes.from_now,
       jti: SecureRandom.hex(32),
-      kid:
+      kid: nil
     )
       @encryption_method = encryption_method
       @scope = scope

--- a/lib/onc_certification_g10_test_kit/bulk_data_authorization.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_authorization.rb
@@ -39,6 +39,10 @@ module ONCCertificationG10TestKit
               }
             ]
           }
+    input :bulk_jwks_kid,
+          title: 'Bulk Data JWKS kid',
+          description: 'The key ID of the JWKS private key to use for signing the client assertion when fetching an auth token. Defaults to the first JWK in the list if no kid is supplied.',
+          optional: true
     output :bearer_token
 
     http_client :token_endpoint do
@@ -85,7 +89,8 @@ module ONCCertificationG10TestKit
                                                                  iss: bulk_client_id,
                                                                  sub: bulk_client_id,
                                                                  aud: bulk_token_endpoint,
-                                                                 grant_type: 'not_a_grant_type')
+                                                                 grant_type: 'not_a_grant_type',
+                                                                 kid: bulk_jwks_kid)
 
         post(**{ client: :token_endpoint }.merge(post_request_content))
 
@@ -116,7 +121,8 @@ module ONCCertificationG10TestKit
                                                                  iss: bulk_client_id,
                                                                  sub: bulk_client_id,
                                                                  aud: bulk_token_endpoint,
-                                                                 client_assertion_type: 'not_an_assertion_type')
+                                                                 client_assertion_type: 'not_an_assertion_type',
+                                                                 kid: bulk_jwks_kid)
 
         post(**{ client: :token_endpoint }.merge(post_request_content))
 
@@ -177,7 +183,8 @@ module ONCCertificationG10TestKit
                                                                  scope: bulk_scope,
                                                                  iss: bulk_client_id,
                                                                  sub: bulk_client_id,
-                                                                 aud: bulk_token_endpoint)
+                                                                 aud: bulk_token_endpoint,
+                                                                 kid: bulk_jwks_kid)
 
         authentication_response = post(**{ client: :token_endpoint }.merge(post_request_content))
 

--- a/lib/onc_certification_g10_test_kit/bulk_data_authorization.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_authorization.rb
@@ -41,7 +41,10 @@ module ONCCertificationG10TestKit
           }
     input :bulk_jwks_kid,
           title: 'Bulk Data JWKS kid',
-          description: 'The key ID of the JWKS private key to use for signing the client assertion when fetching an auth token. Defaults to the first JWK in the list if no kid is supplied.',
+          description: <<~DESCRIPTION,
+            The key ID of the JWKS private key to use for signing the client assertion when fetching an auth token.
+            Defaults to the first JWK in the list if no kid is supplied.
+          DESCRIPTION
           optional: true
     output :bearer_token
 
@@ -161,7 +164,8 @@ module ONCCertificationG10TestKit
                                                                  scope: bulk_scope,
                                                                  iss: 'not_a_valid_iss',
                                                                  sub: bulk_client_id,
-                                                                 aud: bulk_token_endpoint)
+                                                                 aud: bulk_token_endpoint,
+                                                                 kid: bulk_jwks_kid)
 
         post(**{ client: :token_endpoint }.merge(post_request_content))
 


### PR DESCRIPTION
I found that it was useful for my deployment to have multiple JWKS configured for the same algorithm. So I thought to add an optional input parameter for the bulk export tests to allow us to select which one to use via `kid`.

Let me know if you think this is/isn't generally useful for the community. We can continue to use our fork of the project if you don't want to merge this, but I'd prefer to get it merged. In my local testing I found this to behave identically if you do not set the kid input. If you do set it, then it is picking the correct one.

Let me know if there are automated test cases that should be updated or if you have any other suggestions.

Thanks