### PR TITLE
FI-2406: Add Encounter context for US Core 6

### DIFF
--- a/lib/onc_certification_g10_test_kit/short_id_map.yml
+++ b/lib/onc_certification_g10_test_kit/short_id_map.yml
@@ -144,6 +144,7 @@ g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch-g10_smart_scop
 g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch-g10_unauthorized_access: 3.3.11
 g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch-g10_patient_context: 3.3.12
 g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch-g10_encounter_context: 3.3.13
+g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch-g10_encounter_context_us_core_6: 3.3.16
 g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch-Test13: 3.3.14
 g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch-Test14: 3.3.15
 g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch_stu2: '3.4'
@@ -160,6 +161,7 @@ g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch_stu2-g10_smart
 g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch_stu2-g10_unauthorized_access: 3.4.11
 g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch_stu2-g10_patient_context: 3.4.12
 g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch_stu2-g10_encounter_context: 3.4.13
+g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch_stu2-g10_encounter_context_us_core_6: 3.4.16
 g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch_stu2-g10_smart_style_url: 3.4.14
 g10_certification-g10_smart_ehr_practitioner_app-smart_ehr_launch_stu2-g10_smart_need_patient_banner: 3.4.15
 g10_certification-g10_smart_ehr_practitioner_app-smart_openid_connect: '3.5'

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -181,7 +181,7 @@ module ONCCertificationG10TestKit
            required_suite_options: G10Options::US_CORE_5_REQUIREMENT
 
       test from: :g10_encounter_context,
-           id: :g10_encounter_context_us_core_6,
+           id: :g10_encounter_context_us_core_6, # rubocop:disable Naming/VariableNumber
            config: {
              inputs: {
                encounter_id: { name: :ehr_encounter_id },
@@ -337,7 +337,7 @@ module ONCCertificationG10TestKit
            required_suite_options: G10Options::US_CORE_5_REQUIREMENT
 
       test from: :g10_encounter_context,
-           id: :g10_encounter_context_us_core_6,
+           id: :g10_encounter_context_us_core_6, # rubocop:disable Naming/VariableNumber
            config: {
              inputs: {
                encounter_id: { name: :ehr_encounter_id },

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -180,6 +180,16 @@ module ONCCertificationG10TestKit
            },
            required_suite_options: G10Options::US_CORE_5_REQUIREMENT
 
+      test from: :g10_encounter_context,
+           id: :g10_encounter_context_us_core_6,
+           config: {
+             inputs: {
+               encounter_id: { name: :ehr_encounter_id },
+               access_token: { name: :ehr_access_token }
+             }
+           },
+           required_suite_options: G10Options::US_CORE_6_REQUIREMENT
+
       test do
         title 'Launch context contains smart_style_url which links to valid JSON'
         description %(
@@ -325,6 +335,16 @@ module ONCCertificationG10TestKit
              }
            },
            required_suite_options: G10Options::US_CORE_5_REQUIREMENT
+
+      test from: :g10_encounter_context,
+           id: :g10_encounter_context_us_core_6,
+           config: {
+             inputs: {
+               encounter_id: { name: :ehr_encounter_id },
+               access_token: { name: :ehr_access_token }
+             }
+           },
+           required_suite_options: G10Options::US_CORE_6_REQUIREMENT
 
       test do
         title 'Launch context contains smart_style_url which links to valid JSON'


### PR DESCRIPTION
The Encounter context test was missed when adding tests for US Core 6. This branch adds it for SMART 1 & 2.

![Screenshot 2024-01-09 at 9 40 36 AM](https://github.com/onc-healthit/onc-certification-g10-test-kit/assets/15969967/9a726abd-2b4b-4e5f-a070-4567168e5272)

![Screenshot 2024-01-09 at 9 40 02 AM](https://github.com/onc-healthit/onc-certification-g10-test-kit/assets/15969967/11718bb6-85af-47ef-95f2-ba5ec84e9249)
