### PR TITLE
FI-2423: Bump validator dependency to v2.3.2

### DIFF
--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   validator_service:
-    image: infernocommunity/fhir-validator-service:v2.3.1
+    image: infernocommunity/fhir-validator-service:v2.3.2
     environment:
       - DISABLE_TX= true
       - DISPLAY_ISSUES_ARE_WARNINGS=true

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -62,6 +62,15 @@ module ONCCertificationG10TestKit
       /Unknown ValueSet/
     ].freeze
 
+    ERROR_FILTERS = [
+      /\A\S+: \S+: Unknown Code/,
+      /\A\S+: \S+: None of the codings provided are in the value set/,
+      /\A\S+: \S+: The code provided \(\S*\) is not in the value set/,
+      /\A\S+: \S+: The Coding provided \(\S*\) is not in the value set/,
+      /\A\S+: \S+: The Coding provided \(\S*\) was not found in the value set/,
+      /\A\S+: \S+: A definition for CodeSystem '.*' could not be found, so the code cannot be validated/
+    ].freeze
+
     [
       G10Options::US_CORE_3_REQUIREMENT,
       G10Options::US_CORE_4_REQUIREMENT,
@@ -90,14 +99,7 @@ module ONCCertificationG10TestKit
                 filter.match? message.message
               end) ||
              us_core_message_filters.any? { |filter| filter.match? message.message } ||
-             (
-               message.type == 'error' && (
-                 message.message.match?(/\A\S+: \S+: Unknown Code/) ||
-                 message.message.match?(/\A\S+: \S+: None of the codings provided are in the value set/) ||
-                 message.message.match?(/\A\S+: \S+: The code provided \(\S*\) is not in the value set/) ||
-                 message.message.match?(/\A\S+: \S+: The Coding provided \(\S*\) is not in the value set/)
-               )
-             )
+             (message.type == 'error' && ERROR_FILTERS.any? { |filter| message.message.match? filter })
             true
           else
             false

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -2,7 +2,7 @@ require_relative '../inferno/terminology/tasks/check_built_terminology'
 
 module ONCCertificationG10TestKit
   class ConfigurationChecker
-    EXPECTED_VALIDATOR_VERSION = '2.3.1'.freeze
+    EXPECTED_VALIDATOR_VERSION = '2.3.2'.freeze
 
     def configuration_messages
       validator_version_message + terminology_messages + version_message


### PR DESCRIPTION
Bump the validator to release 2.3.2 and update the message filters to handle new error messages. Note there are 2 new messages, one a slight variation of an existing message ("_ is not in the value set" vs "_ was not found in the value set") and one brand new "A definition for CodeSystem '.*' could not be found, so the code cannot be validated". 

I extracted the message regexes into a list only because the new message text is long and this felt cleaner than a multi-line regex