### PR TITLE
FI-2470 Inferno Core Input Optional Fixes

### DIFF
--- a/lib/onc_certification_g10_test_kit/incorrectly_permitted_tls_versions_messages_setup_test.rb
+++ b/lib/onc_certification_g10_test_kit/incorrectly_permitted_tls_versions_messages_setup_test.rb
@@ -3,7 +3,8 @@ module ONCCertificationG10TestKit
     id :g10_incorrectly_permitted_tls_versions_messages_setup
     title 'Handle TLS Warning Messages'
 
-    input :incorrectly_permitted_tls_versions_messages
+    input :incorrectly_permitted_tls_versions_messages,
+      optional: true
     output :unique_incorrectly_permitted_tls_versions_messages,
            :tls_documentation_required
 

--- a/lib/onc_certification_g10_test_kit/smart_invalid_token_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_invalid_token_group.rb
@@ -142,7 +142,9 @@ module ONCCertificationG10TestKit
       )
       uses_request :redirect
 
-      input :use_pkce, :pkce_code_verifier, :client_id, :client_secret, :smart_token_url
+      input :use_pkce, :client_id, :client_secret, :smart_token_url
+      input :pkce_code_verifier,
+            optional: true
 
       run do
         skip_if request.query_parameters['error'].present?, 'Error during authorization request'
@@ -177,7 +179,9 @@ module ONCCertificationG10TestKit
       )
       uses_request :redirect
 
-      input :use_pkce, :pkce_code_verifier, :code, :smart_token_url, :client_secret
+      input :use_pkce, :code, :smart_token_url, :client_secret
+      input :pkce_code_verifier,
+            optional: true
 
       run do
         skip_if request.query_parameters['error'].present?, 'Error during authorization request'

--- a/lib/onc_certification_g10_test_kit/smart_invalid_token_group_stu2.rb
+++ b/lib/onc_certification_g10_test_kit/smart_invalid_token_group_stu2.rb
@@ -148,8 +148,9 @@ module ONCCertificationG10TestKit
       )
       uses_request :redirect
 
-      input :use_pkce, :pkce_code_verifier, :client_id, :client_secret, :smart_token_url
-
+      input :use_pkce, :client_id, :client_secret, :smart_token_url
+      input :pkce_code_verifier,
+            optional: true
       run do
         skip_if request.query_parameters['error'].present?, 'Error during authorization request'
 
@@ -183,7 +184,9 @@ module ONCCertificationG10TestKit
       )
       uses_request :redirect
 
-      input :use_pkce, :pkce_code_verifier, :code, :smart_token_url, :client_secret
+      input :use_pkce, :code, :smart_token_url, :client_secret
+      input :pkce_code_verifier,
+            optional: true
 
       run do
         skip_if request.query_parameters['error'].present?, 'Error during authorization request'

--- a/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
+++ b/lib/onc_certification_g10_test_kit/visual_inspection_and_attestations_group.rb
@@ -506,6 +506,7 @@ module ONCCertificationG10TestKit
             title: 'Health IT developers must document how the Health IT Module enforces TLs version 1.2 or above.',
             type: 'radio',
             default: 'false',
+            optional: true,
             locked: true,
             options: {
               list_options: [


### PR DESCRIPTION
Before running each test, inferno_core now will check each input and will skip the test if an input is required and not populated. This PR fixes some issues that occur in the (g)(10) test kit as a result, by making some test inputs optional that should not be causing the test to skip when they are not populated. 