### PR TITLE
FI-2532: Add feature flag to toggle using HL7 validator wrapper

### DIFF
--- a/config/nginx.background.conf
+++ b/config/nginx.background.conf
@@ -68,20 +68,20 @@ http {
     #   proxy_pass http://fhir_validator_app;
     # }
 
-   # location /validatorapi/ {
-   #   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-   #   proxy_set_header Host $http_host;
-   #   proxy_set_header X-Forwarded-Proto $scheme;
-   #   proxy_set_header X-Forwarded-Port $server_port;
-   #   proxy_redirect off;
-   #   proxy_set_header Connection '';
-   #   proxy_http_version 1.1;
-   #   chunked_transfer_encoding off;
-   #   proxy_buffering off;
-   #   proxy_cache off;
+    location /validatorapi/ {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
 
-   #   proxy_pass http://validator_service:4567/;
-   # }
+      proxy_pass http://validator_service:4567/;
+    }
 
     location /hl7validatorapi/ {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -1,12 +1,12 @@
 version: '3'
 services:
-  # validator_service:
-  #   image: infernocommunity/fhir-validator-service:v2.3.2
-  #   environment:
-  #     - DISABLE_TX= true
-  #     - DISPLAY_ISSUES_ARE_WARNINGS=true
-  #   volumes:
-  #     - ./lib/onc_certification_g10_test_kit/igs:/home/igs
+  validator_service:
+    image: infernocommunity/fhir-validator-service:v2.3.2
+    environment:
+      - DISABLE_TX= true
+      - DISPLAY_ISSUES_ARE_WARNINGS=true
+    volumes:
+      - ./lib/onc_certification_g10_test_kit/igs:/home/igs
   # fhir_validator_app:
   #   image: infernocommunity/fhir-validator-app
   #   depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./data:/opt/inferno/data
     depends_on:
       - hl7_validator_service
-    #   - validator_service
+      - validator_service
   worker:
     build:
       context: ./
@@ -16,10 +16,10 @@ services:
     command: bundle exec sidekiq -r ./worker.rb
     depends_on:
       - redis
-  # validator_service:
-  #   extends:
-  #     file: docker-compose.background.yml
-  #     service: validator_service
+  validator_service:
+    extends:
+      file: docker-compose.background.yml
+      service: validator_service
   # fhir_validator_app:
   #   extends:
   #     file: docker-compose.background.yml

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -73,14 +73,14 @@ module ONCCertificationG10TestKit
     ].freeze
 
     def self.setup_validator(us_core_version_requirement) # rubocop:disable Metrics/CyclomaticComplexity
-      validator_method = if Feature.use_new_resource_validator?
+      validator_method = if Feature.use_hl7_resource_validator?
                            method(:fhir_resource_validator)
                          else
                            method(:validator)
                          end
 
       validator_method.call :default, required_suite_options: us_core_version_requirement do
-        if Feature.use_new_resource_validator?
+        if Feature.use_hl7_resource_validator?
           url ENV.fetch('G10_FHIR_RESOURCE_VALIDATOR_URL', 'http://hl7_validator_service:3500')
 
           cli_context do

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -22,7 +22,7 @@ module ONCCertificationG10TestKit
     end
 
     def validator_version_message
-      if Feature.use_new_resource_validator?
+      if Feature.use_hl7_resource_validator?
         expected_validator_version = EXPECTED_HL7_VALIDATOR_VERSION
         validator_version_url = "#{validator_url}/validator/version"
       else

--- a/lib/onc_certification_g10_test_kit/feature.rb
+++ b/lib/onc_certification_g10_test_kit/feature.rb
@@ -1,8 +1,8 @@
 module ONCCertificationG10TestKit
   module Feature
     class << self
-      def use_new_resource_validator?
-        ENV.fetch('USE_NEW_RESOURCE_VALIDATOR', 'false')&.casecmp?('true')
+      def use_hl7_resource_validator?
+        ENV.fetch('USE_HL7_RESOURCE_VALIDATOR', 'false')&.casecmp?('true')
       end
     end
   end

--- a/lib/onc_certification_g10_test_kit/feature.rb
+++ b/lib/onc_certification_g10_test_kit/feature.rb
@@ -1,10 +1,9 @@
 module ONCCertificationG10TestKit
   module Feature
-    class << self # rubocop:disable Lint/EmptyClass
-      # This is how you can define feature flags to be used in the g10 test kit
-      # def us_core_v4?
-      #   ENV.fetch('US_CORE_4_ENABLED', 'false')&.casecmp?('true')
-      # end
+    class << self
+      def use_new_resource_validator?
+        ENV.fetch('USE_NEW_RESOURCE_VALIDATOR', 'false')&.casecmp?('true')
+      end
     end
   end
 end

--- a/lib/onc_certification_g10_test_kit/g10_options.rb
+++ b/lib/onc_certification_g10_test_kit/g10_options.rb
@@ -5,6 +5,13 @@ module ONCCertificationG10TestKit
     US_CORE_5 = 'us_core_5'.freeze
     US_CORE_6 = 'us_core_6'.freeze
 
+    US_CORE_VERSION_NUMBERS = {
+      US_CORE_3 => '3.1.1',
+      US_CORE_4 => '4.0.0',
+      US_CORE_5 => '5.0.1',
+      US_CORE_6 => '6.1.0'
+    }.freeze
+
     BULK_DATA_1 = 'multi_patient_api_stu1'.freeze
     BULK_DATA_2 = 'multi_patient_api_stu2'.freeze
 

--- a/spec/fixtures/ValidationResponse-code-invalid-1.json
+++ b/spec/fixtures/ValidationResponse-code-invalid-1.json
@@ -1,0 +1,42 @@
+{
+    "outcomes": [
+        {
+            "fileInfo": {
+                "fileName": "manually_entered_file.json",
+                "fileContent": "{\n  \"resourceType\": \"Immunization\",\n  \"subpotentReason\": [{\n    \"coding\": [{\n      \"system\": \"http://terminology.hl7.org/CodeSystem/immunization-subpotent-reason\",\n      \"code\": \"partialdose\"\n    }]\n  }]\n}",
+                "fileType": "json"
+            },
+            "issues": [
+                {
+                    "source": "TerminologyEngine",
+                    "server": null,
+                    "line": 3,
+                    "col": 4,
+                    "location": "Immunization.subpotentReason[0].coding[0].code",
+                    "message": "Unknown code 'partialdose' in the CodeSystem 'http://terminology.hl7.org/CodeSystem/immunization-subpotent-reason' version '1.0.0'",
+                    "messageId": null,
+                    "type": "CODEINVALID",
+                    "level": "ERROR",
+                    "html": "Unknown code 'partialdose' in the CodeSystem 'http://terminology.hl7.org/CodeSystem/immunization-subpotent-reason' version '1.0.0'",
+                    "locationLink": null,
+                    "txLink": null,
+                    "sliceHtml": null,
+                    "sliceText": null,
+                    "slicingHint": false,
+                    "signpost": false,
+                    "criticalSignpost": false,
+                    "ruleDate": null,
+                    "matched": false,
+                    "ignorableError": false,
+                    "invId": null,
+                    "comment": null,
+                    "sliceInfo": null,
+                    "error": true,
+                    "display": "ERROR: Immunization.subpotentReason[0].coding[0].code: Unknown code 'partialdose' in the CodeSystem 'http://terminology.hl7.org/CodeSystem/immunization-subpotent-reason' version '1.0.0'"
+                }
+            ]
+        }
+    ],
+    "sessionId": "f4af8f4f-15d0-44f3-8401-dc9f9014aeaf",
+    "validationTimes": {}
+}

--- a/spec/fixtures/ValidationResponse-code-invalid-2.json
+++ b/spec/fixtures/ValidationResponse-code-invalid-2.json
@@ -1,0 +1,40 @@
+{
+  "outcomes" : [ {
+    "fileInfo" : {
+      "fileName" : "manually_entered_file.json",
+      "fileContent" : "{\n  \"resourceType\": \"AllergyIntolerance\",\n  \"clinicalStatus\": {\n    \"coding\": [\n      {\n        \"system\": \"http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical\",\n        \"code\": \"actives\",\n        \"display\": \"Active\"\n      }\n    ]\n  }\n}",
+      "fileType" : "json"
+    },
+    "issues" : [ 
+    {
+      "source" : "TerminologyEngine",
+      "server" : null,
+      "line" : 3,
+      "col" : 4,
+      "location" : "AllergyIntolerance.clinicalStatus",
+      "message" : "None of the codings provided are in the value set 'AllergyIntolerance Clinical Status Codes' (http://hl7.org/fhir/ValueSet/allergyintolerance-clinical|4.0.1), and a coding from this value set is required) (codes = http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical#actives)",
+      "messageId" : "Terminology_TX_NoValid_1_CC",
+      "type" : "CODEINVALID",
+      "level" : "ERROR",
+      "html" : "None of the codings provided are in the value set 'AllergyIntolerance Clinical Status Codes' (http://hl7.org/fhir/ValueSet/allergyintolerance-clinical|4.0.1), and a coding from this value set is required) (codes = http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical#actives)",
+      "locationLink" : null,
+      "txLink" : null,
+      "sliceHtml" : null,
+      "sliceText" : null,
+      "slicingHint" : false,
+      "signpost" : false,
+      "criticalSignpost" : false,
+      "ruleDate" : null,
+      "matched" : false,
+      "ignorableError" : false,
+      "invId" : null,
+      "comment" : null,
+      "sliceInfo" : null,
+      "display" : "ERROR: AllergyIntolerance.clinicalStatus: None of the codings provided are in the value set 'AllergyIntolerance Clinical Status Codes' (http://hl7.org/fhir/ValueSet/allergyintolerance-clinical|4.0.1), and a coding from this value set is required) (codes = http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical#actives)",
+      "error" : true
+    }
+  ]
+  } ],
+  "sessionId" : "7c0cb248-4dd9-4063-9ed9-03623bbe221a",
+  "validationTimes" : { }
+}

--- a/spec/fixtures/ValidationResponse-code-invalid-3.json
+++ b/spec/fixtures/ValidationResponse-code-invalid-3.json
@@ -1,0 +1,38 @@
+{
+  "outcomes" : [ {
+    "fileInfo" : {
+      "fileName" : "manually_entered_file.json",
+      "fileContent" : "{\n      \"resourceType\": \"Patient\",\n      \n      \"extension\": [ {\n        \"url\": \"http://hl7.org/fhir/us/core/StructureDefinition/us-core-race\",\n        \"extension\": [ {\n          \"url\": \"ombCategory\",\n          \"valueCoding\": {\n            \"system\": \"urn:oid:2.16.840.1.113883.6.238\",\n            \"code\": \"2299-0\",\n            \"display\": \"Asian\"\n          }\n        }, {\n          \"url\": \"text\",\n          \"valueString\": \"Asian\"\n        } ]\n      }, \n      {\n        \"url\": \"http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity\",\n        \"extension\": [ {\n          \"url\": \"ombCategory\",\n          \"valueCoding\": {\n            \"system\": \"urn:oid:2.16.840.1.113883.6.238\",\n            \"code\": \"2186-5\",\n            \"display\": \"Not Hispanic or Latino\"\n          }\n        }, {\n          \"url\": \"text\",\n          \"valueString\": \"Not Hispanic or Latino\"\n        } ]\n      }\n   ]\n}",
+      "fileType" : "json"
+    },
+    "issues" : [{
+      "source" : "TerminologyEngine",
+      "server" : null,
+      "line" : 8,
+      "col" : 12,
+      "location" : "Patient.extension[0].extension[0].value.ofType(Coding)",
+      "message" : "The Coding provided (urn:oid:2.16.840.1.113883.6.238#2106-3) is not in the value set http://hl7.org/fhir/us/core/ValueSet/omb-race-category, and a code is required from this value set. (error message = Not in value set http://hl7.org/fhir/us/core/ValueSet/omb-race-category)",
+      "messageId" : "Terminology_TX_Confirm_4a",
+      "type" : "CODEINVALID",
+      "level" : "ERROR",
+      "html" : "The Coding provided (urn:oid:2.16.840.1.113883.6.238#2106-3) is not in the value set http://hl7.org/fhir/us/core/ValueSet/omb-race-category, and a code is required from this value set. (error message = Not in value set http://hl7.org/fhir/us/core/ValueSet/omb-race-category)",
+      "locationLink" : null,
+      "txLink" : null,
+      "sliceHtml" : null,
+      "sliceText" : null,
+      "slicingHint" : false,
+      "signpost" : false,
+      "criticalSignpost" : false,
+      "ruleDate" : null,
+      "matched" : false,
+      "ignorableError" : false,
+      "invId" : null,
+      "comment" : null,
+      "sliceInfo" : null,
+      "display" : "ERROR: Patient.extension[0].extension[0].value.ofType(Coding): The Coding provided (urn:oid:2.16.840.1.113883.6.238#2106-3) is not in the value set http://hl7.org/fhir/us/core/ValueSet/omb-race-category, and a code is required from this value set. (error message = Not in value set http://hl7.org/fhir/us/core/ValueSet/omb-race-category)",
+      "error" : true
+    }]
+  } ],
+  "sessionId" : "7c0cb248-4dd9-4063-9ed9-03623bbe221a",
+  "validationTimes" : { }
+}

--- a/spec/fixtures/ValidationResponse-no-name.json
+++ b/spec/fixtures/ValidationResponse-no-name.json
@@ -1,0 +1,38 @@
+{
+        "outcomes" : [ {
+          "fileInfo" : {
+            "fileName" : "manually_entered_file.json",
+            "fileContent" : "{ \"resourceType\": \"Patient\" }",
+            "fileType" : "json"
+          },
+          "issues" : [{
+            "source" : "InstanceValidator",
+            "server" : null,
+            "line" : 1,
+            "col" : 30,
+            "location" : "Patient",
+            "message" : "Patient.name: minimum required = 1, but only found 0 (from http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1)",
+            "messageId" : "Validation_VAL_Profile_Minimum",
+            "type" : "STRUCTURE",
+            "level" : "ERROR",
+            "html" : "Patient.name: minimum required = 1, but only found 0 (from http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1)",
+            "locationLink" : null,
+            "txLink" : null,
+            "sliceHtml" : null,
+            "sliceText" : null,
+            "slicingHint" : false,
+            "signpost" : false,
+            "criticalSignpost" : false,
+            "ruleDate" : null,
+            "matched" : false,
+            "ignorableError" : false,
+            "invId" : null,
+            "comment" : null,
+            "sliceInfo" : null,
+            "display" : "ERROR: Patient: Patient.name: minimum required = 1, but only found 0 (from http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1)",
+            "error" : true
+          } ]
+        } ],
+        "sessionId" : "4d9d2dc3-5df1-461f-a4d6-bfc2788a1933",
+        "validationTimes" : { }
+      }

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
         .to_return(status: 200, body: contents, headers:)
 
       # Ideally this would run twice, once with each validator setting
-      if ONCCertificationG10TestKit::Feature.use_new_resource_validator?
+      if ONCCertificationG10TestKit::Feature.use_hl7_resource_validator?
         validation_stub_url = "#{validator_url}/validate"
         validation_stub_body = validation_response_no_name
       else

--- a/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe 'Resource Validation' do # rubocop:disable RSpec/DescribeClass
   let(:resource) { FHIR.from_contents('{"resourceType": "Immunization", "id": "123"}') }
 
-  def reset_g10_validators(use_new_resource_validator)
+  def reset_g10_validators(use_hl7_resource_validator)
     ONCCertificationG10TestKit::G10CertificationSuite.fhir_validators[:default].clear
 
-    ENV['USE_NEW_RESOURCE_VALIDATOR'] = use_new_resource_validator.to_s
+    ENV['USE_HL7_RESOURCE_VALIDATOR'] = use_hl7_resource_validator.to_s
 
     [
       ONCCertificationG10TestKit::G10Options::US_CORE_3_REQUIREMENT,

--- a/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
@@ -1,52 +1,117 @@
 RSpec.describe 'Resource Validation' do # rubocop:disable RSpec/DescribeClass
-  let(:runnable) { ONCCertificationG10TestKit::G10CertificationSuite.groups.first.groups.first.tests.first.new }
   let(:resource) { FHIR.from_contents('{"resourceType": "Immunization", "id": "123"}') }
-  let(:validator_url) { runnable.find_validator(:default).url }
-  let(:operation_outcome_string1) do
-    File.read(File.join(__dir__, '..', 'fixtures', 'OperationOutcome-code-invalid-1.json'))
-  end
-  let(:operation_outcome_string2) do
-    File.read(File.join(__dir__, '..', 'fixtures', 'OperationOutcome-code-invalid-2.json'))
-  end
 
-  it 'excludes Unknown Code messages' do
-    stub_request(:post, "#{validator_url}/validate?profile=PROFILE")
-      .to_return(status: 200, body: operation_outcome_string1)
+  def reset_g10_validators(use_new_resource_validator)
+    ONCCertificationG10TestKit::G10CertificationSuite.fhir_validators[:default].clear
 
-    expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
-    expect(runnable.messages.length).to be_zero
-  end
+    ENV['USE_NEW_RESOURCE_VALIDATOR'] = use_new_resource_validator.to_s
 
-  it 'excludes CodeableConcept not in VS messages' do
-    stub_request(:post, "#{validator_url}/validate?profile=PROFILE")
-      .to_return(status: 200, body: operation_outcome_string2)
+    [
+      ONCCertificationG10TestKit::G10Options::US_CORE_3_REQUIREMENT,
+      ONCCertificationG10TestKit::G10Options::US_CORE_4_REQUIREMENT,
+      ONCCertificationG10TestKit::G10Options::US_CORE_5_REQUIREMENT,
+      ONCCertificationG10TestKit::G10Options::US_CORE_6_REQUIREMENT
 
-    expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
-    expect(runnable.messages.length).to be_zero
+    ].each do |us_core_version_requirement|
+      ONCCertificationG10TestKit::G10CertificationSuite.setup_validator(us_core_version_requirement)
+    end
   end
 
-  it 'excludes Coding not in VS messages' do
-    oo = FHIR::OperationOutcome.new(
-      issue: [
-        {
-          severity: 'error',
-          code: 'code-invalid',
-          details: {
-            text: 'The Coding provided (urn:oid:2.16.840.1.113883.6.238#2106-3) is not in the value set ' \
-                  'http://hl7.org/fhir/us/core/ValueSet/omb-race-category, and a code is required from ' \
-                  'this value set. (error message = Not in value set ' \
-                  'http://hl7.org/fhir/us/core/ValueSet/omb-race-category)'
-          },
-          expression: [
-            'Patient.extension[0].extension[0].value.ofType(Coding)'
-          ]
-        }
-      ]
-    )
-    stub_request(:post, "#{validator_url}/validate?profile=PROFILE")
-      .to_return(status: 200, body: oo.to_json)
+  describe 'with Inferno validator wrapper' do
+    before do
+      reset_g10_validators(false)
+    end
 
-    expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
-    expect(runnable.messages.length).to be_zero
+    let(:runnable) { ONCCertificationG10TestKit::G10CertificationSuite.groups.first.groups.first.tests.first.new }
+    let(:validator_url) { runnable.find_validator(:default).url }
+    let(:operation_outcome_string1) do
+      File.read(File.join(__dir__, '..', 'fixtures', 'OperationOutcome-code-invalid-1.json'))
+    end
+    let(:operation_outcome_string2) do
+      File.read(File.join(__dir__, '..', 'fixtures', 'OperationOutcome-code-invalid-2.json'))
+    end
+
+    it 'excludes Unknown Code messages' do
+      stub_request(:post, "#{validator_url}/validate?profile=PROFILE")
+        .to_return(status: 200, body: operation_outcome_string1)
+
+      expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
+      expect(runnable.messages.length).to be_zero
+    end
+
+    it 'excludes CodeableConcept not in VS messages' do
+      stub_request(:post, "#{validator_url}/validate?profile=PROFILE")
+        .to_return(status: 200, body: operation_outcome_string2)
+
+      expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
+      expect(runnable.messages.length).to be_zero
+    end
+
+    it 'excludes Coding not in VS messages' do
+      oo = FHIR::OperationOutcome.new(
+        issue: [
+          {
+            severity: 'error',
+            code: 'code-invalid',
+            details: {
+              text: 'The Coding provided (urn:oid:2.16.840.1.113883.6.238#2106-3) is not in the value set ' \
+                    'http://hl7.org/fhir/us/core/ValueSet/omb-race-category, and a code is required from ' \
+                    'this value set. (error message = Not in value set ' \
+                    'http://hl7.org/fhir/us/core/ValueSet/omb-race-category)'
+            },
+            expression: [
+              'Patient.extension[0].extension[0].value.ofType(Coding)'
+            ]
+          }
+        ]
+      )
+      stub_request(:post, "#{validator_url}/validate?profile=PROFILE")
+        .to_return(status: 200, body: oo.to_json)
+
+      expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
+      expect(runnable.messages.length).to be_zero
+    end
+  end
+
+  describe 'with HL7 validator wrapper' do
+    before do
+      reset_g10_validators(true)
+    end
+
+    let(:runnable) { ONCCertificationG10TestKit::G10CertificationSuite.groups.first.groups.first.tests.first.new }
+    let(:validator_url) { runnable.find_validator(:default).url }
+    let(:validation_response_string1) do
+      File.read(File.join(__dir__, '..', 'fixtures', 'ValidationResponse-code-invalid-1.json'))
+    end
+    let(:validation_response_string2) do
+      File.read(File.join(__dir__, '..', 'fixtures', 'ValidationResponse-code-invalid-2.json'))
+    end
+    let(:validation_response_string3) do
+      File.read(File.join(__dir__, '..', 'fixtures', 'ValidationResponse-code-invalid-3.json'))
+    end
+
+    it 'excludes Unknown Code messages' do
+      stub_request(:post, "#{validator_url}/validate")
+        .to_return(status: 200, body: validation_response_string1)
+
+      expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
+      expect(runnable.messages.length).to be_zero
+    end
+
+    it 'excludes CodeableConcept not in VS messages' do
+      stub_request(:post, "#{validator_url}/validate")
+        .to_return(status: 200, body: validation_response_string2)
+
+      expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
+      expect(runnable.messages.length).to be_zero
+    end
+
+    it 'excludes Coding not in VS messages' do
+      stub_request(:post, "#{validator_url}/validate")
+        .to_return(status: 200, body: validation_response_string3)
+
+      expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
+      expect(runnable.messages.length).to be_zero
+    end
   end
 end


### PR DESCRIPTION
This PR adds a new feature flag to toggle between using the current Inferno validator wrapper and the HL7 validator wrapper. Set env var `USE_HL7_RESOURCE_VALIDATOR = true` to switch over to the HL7 validator, leave it blank/unset or set to anything else and it will use the current Inferno validator.

## Summary of code changes
To make this a "one-click" toggle we'll need to have both validators enabled in the docker-compose file and nginx. With that in mind some of the changes here are just reverting changes from the WIP branch on #488 to re-enable the Inferno validator, so it may be useful to review the diff against `main` as well.  If we're ok with the 3-step directions of "change env var, uncomment this service in docker-compose.yml, uncomment this section in nginx.conf" then we could leave the the HL7 validator entries commented out by default.

The real logic that handles the toggle is in `onc_certification_g10_test_kit.rb` - just a simple `if` so that the  `cliContext` and `igs` settings aren't called for the inferno validator, and a conditional to call `validator` vs `fhir_resource_validator`.
I also noticed an instance where the capitalization of one error message made it slip through the filter so I updated that here as well.

Most of the remaining changes are for testing purposes. I didn't want to just skip tests depending on an env var, so I duplicated the `resource_validation_spec.rb` tests to run once for each type of validator. To make that work I needed a way to "reset" the validators so they reload appropriately per the env var. The simplest approach was to break the validator setup logic out into its own function that could be invoked later. Unfortunately rubocop checks cyclomatic complexity on method but not arbitrary blocks in the class definition so that didn't pass rubocop. Rather than a more significant refactor I just disabled that check in that one spot. If there's a better way to do this kind of "class reload" let me know. Then there's another test that I didn't know if it was worth a more significant refactor: `bulk_data_group_export_validation_spec.rb`, so this test just checks the current state of the env var and handles it appropriately. Let me know if this is worth digging more into.

## Testing Guidance
No special guidance needed - as currently configured this should require only the one env var to be changed to toggle the desired result. You don't even need to restart services after toggling the option.