### PR TITLE
FI-2523 Ignore Bulk Data Device resource 

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_export_validation_tester.rb
@@ -92,7 +92,7 @@ module ONCCertificationG10TestKit
     end
 
     def determine_profile(resource)
-      return if resource.resourceType == 'Device' && !predefined_device_type?(resource)
+      return [] if resource.resourceType == 'Device' && !predefined_device_type?(resource)
 
       select_profile(resource)
     end

--- a/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_export_validation_tester_spec.rb
@@ -340,11 +340,11 @@ RSpec.describe ONCCertificationG10TestKit::BulkExportValidationTester do
   end
 
   describe '#determine_profile' do
-    it 'returns nil if given a Device resource that is not predefined' do
+    it 'returns empty if given a Device resource that is not predefined' do
       tester.bulk_device_types_in_group = 'not_it'
 
       result = tester.determine_profile(device_resource)
-      expect(result).to be_nil
+      expect(result).to be_empty
     end
 
     it 'returns the vice profile if given a Device resource that is predefined' do


### PR DESCRIPTION
This fix GitHub Issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/494

When tester specifies expected Device type code and Bulk Data validation ignore those lines/resources do not match the input Device type code.

Changes:
* Change return from nil to empty array so that the following loop does not fail.