### PR TITLE
FI-2564 Update attestation for token revocation to include time limit.

### DIFF
--- a/config/presets/g10_reference_server_preset.json
+++ b/config/presets/g10_reference_server_preset.json
@@ -526,7 +526,7 @@
     {
       "name": "token_revocation_attestation",
       "type": "radio",
-      "title": "Within one hour of executing test, Health IT developer demonstrated revoking tokens provided during patient standalone launch.",
+      "title": "The HealthIT developer demonstrated a patient request for revoking the tokens provided during the patient standalone launch within the last hour",
       "options": {
         "list_options": [
           {

--- a/config/presets/g10_reference_server_preset.json
+++ b/config/presets/g10_reference_server_preset.json
@@ -526,7 +526,7 @@
     {
       "name": "token_revocation_attestation",
       "type": "radio",
-      "title": "Prior to executing test, Health IT developer demonstrated revoking tokens provided during patient standalone launch.",
+      "title": "Within one hour of executing test, Health IT developer demonstrated revoking tokens provided during patient standalone launch.",
       "options": {
         "list_options": [
           {

--- a/lib/onc_certification_g10_test_kit/token_revocation_group.rb
+++ b/lib/onc_certification_g10_test_kit/token_revocation_group.rb
@@ -1,7 +1,11 @@
 module ONCCertificationG10TestKit
   class TokenRevocationGroup < Inferno::TestGroup
     title 'Token Revocation'
-    description 'Demonstrate the Health IT module is capable of revoking access granted to an application.'
+    description %(
+      Demonstrate the Health IT module is capable of revoking access granted to
+      an application at the direction of a patient.  Access to the application
+      must be revoked within one hour of the patient's request.
+    )
     id :g10_token_revocation
     run_as_group
 

--- a/lib/onc_certification_g10_test_kit/token_revocation_group.rb
+++ b/lib/onc_certification_g10_test_kit/token_revocation_group.rb
@@ -16,14 +16,15 @@ module ONCCertificationG10TestKit
                 :standalone_client_secret
 
     test do
-      title 'Health IT developer demonstrated the ability of the Health IT Module to revoke tokens.'
+      title 'Health IT developer demonstrated the ability of the Health IT Module to revoke tokens within one hour of a patient\'s request.' # rubocop:disable Layout/LineLength
       description %(
         Health IT developer demonstrated the ability of the Health IT Module /
-        authorization server to revoke tokens.
+        authorization server to revoke tokens at a patient's direction within one
+        hour of the request.
       )
 
       input :token_revocation_attestation,
-            title: 'Prior to executing test, Health IT developer demonstrated revoking tokens provided during patient standalone launch.', # rubocop:disable Layout/LineLength
+            title: 'Within one hour of executing test, Health IT developer demonstrated revoking tokens provided during patient standalone launch.', # rubocop:disable Layout/LineLength
             type: 'radio',
             default: 'false',
             options: {
@@ -45,7 +46,7 @@ module ONCCertificationG10TestKit
 
       run do
         assert token_revocation_attestation == 'true',
-               'Health IT Module did not demonstrate the ability to revoke tokens.'
+               'Health IT Module did not demonstrate the ability to revoke tokens within one hour of request.'
         pass token_revocation_notes if token_revocation_notes.present?
       end
     end

--- a/lib/onc_certification_g10_test_kit/token_revocation_group.rb
+++ b/lib/onc_certification_g10_test_kit/token_revocation_group.rb
@@ -56,7 +56,7 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'Access to Patient resource returns unauthorized within one hour of a patient\'s request to revoke token.'
+      title 'Access to Patient resource returns unauthorized after token revocation.'
       description %(
         This test checks that the Patient resource returns unuathorized after token revocation.
       )
@@ -93,9 +93,9 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'Token refresh fails within one hour of a patient\'s request to revoke token.'
+      title 'Token refresh fails after token revocation.'
       description %(
-        This test checks that refreshing token fails after token revokation.
+        This test checks that refreshing token fails after token revocation.
       )
 
       input :smart_token_url,

--- a/lib/onc_certification_g10_test_kit/token_revocation_group.rb
+++ b/lib/onc_certification_g10_test_kit/token_revocation_group.rb
@@ -24,7 +24,7 @@ module ONCCertificationG10TestKit
       )
 
       input :token_revocation_attestation,
-            title: 'Within one hour of executing test, Health IT developer demonstrated revoking tokens provided during patient standalone launch.', # rubocop:disable Layout/LineLength
+            title: 'The Health IT developer demonstrated a patient\'s request for revoking the tokens provided during the patient standalone launch within the last hour', # rubocop:disable Layout/LineLength
             type: 'radio',
             default: 'false',
             options: {
@@ -46,13 +46,13 @@ module ONCCertificationG10TestKit
 
       run do
         assert token_revocation_attestation == 'true',
-               'Health IT Module did not demonstrate the ability to revoke tokens within one hour of request.'
+               'Health IT Module did not demonstrate a patient\'s request for revoking the tokens within the last hour.'
         pass token_revocation_notes if token_revocation_notes.present?
       end
     end
 
     test do
-      title 'Access to Patient resource returns unauthorized after token revocation.'
+      title 'Access to Patient resource returns unauthorized within one hour of a patient\'s request to revoke token.'
       description %(
         This test checks that the Patient resource returns unuathorized after token revocation.
       )
@@ -89,7 +89,7 @@ module ONCCertificationG10TestKit
     end
 
     test do
-      title 'Token refresh fails after token revocation.'
+      title 'Token refresh fails within one hour of a patient\'s request to revoke token.'
       description %(
         This test checks that refreshing token fails after token revokation.
       )


### PR DESCRIPTION
ONC has updated their requirement for token revocation to be clear that they must be complete within one hour of the patient request.  See [rule](https://www.federalregister.gov/d/2023-28857/p-3013).  This goes into effect March 11.

**NOTE: this changes the name of a test. I do not believe this has any significant downstream effects (e.g. breaking the test mapping across versions, for example).  But if it does let me know.**

<img width="599" alt="Screenshot 2024-03-07 at 2 11 15 PM" src="https://github.com/onc-healthit/onc-certification-g10-test-kit/assets/412901/c3df31ca-8e7b-4791-8ef6-9b2b80ecf768">
