### PR TITLE
FI-2645 Remove US Core 5.0.1 from descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ series of HTTP requests that mimic a real world client to ensure that the API
 supports an approved version of each of the required standards:
 
 * Health Level 7 (HL7®) Fast Healthcare Interoperability Resources (FHIR®) (v4.0.1)
-* US Core Implementation Guide (v3.1.1, v4.0.0, v5.0.1, or v6.1.0)
+* US Core Implementation Guide (v3.1.1, v4.0.0, or v6.1.0)
 * SMART Application Launch Framework Implementation Guide Release (v1.0.0, or
   v2.0.0)
 * HL7 FHIR Bulk Data Access (Flat FHIR) (v1.0.1, or v2.0.0)

--- a/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_group_export_validation.rb
@@ -207,7 +207,7 @@ module ONCCertificationG10TestKit
         * http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition
 
 
-        For US Core v5.0.1, evidence of support for the following two profiles must be demonstrated:
+        For US Core v6.1.0, evidence of support for the following two profiles must be demonstrated:
 
         * http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis
         * http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns
@@ -377,28 +377,6 @@ module ONCCertificationG10TestKit
 
         For US Core v4.0.0, this test expects evidence of the following US Core profiles
 
-        * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age
-        * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus
-        * http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate
-
-        For US Core v5.0.1, this test expects evidence of the following US Core profiles
-
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-clinical-test
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-imaging
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-sexual-orientation
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-social-history
-        * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-sdoh-assessment
         * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age
         * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height
         * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab

--- a/lib/onc_certification_g10_test_kit/onc_program_procedure.yml
+++ b/lib/onc_certification_g10_test_kit/onc_program_procedure.yml
@@ -259,7 +259,7 @@ procedure:
             not include support for “plain”
 
           Additionally, the following “capabilities” must be supported if using
-          US Core 5.0.1 or 6.1.0:
+          US Core 6.1.0:
           * "context-ehr-encounter"
         TLV: |
           [Both] The tester verifies the ability of the
@@ -282,7 +282,7 @@ procedure:
             not include support for “plain”
 
           Additionally, the following “capabilities” must be supported if using
-          US Core 5.0.1 or 6.1.0:
+          US Core 6.1.0:
           * "context-ehr-encounter"
         inferno_supported: 'yes'
         inferno_tests:
@@ -515,7 +515,7 @@ procedure:
           adopted in § 170.213 and implementation specification adopted in
           § 170.215(a)(2).
 
-          If using US Core 3.1.1, 4.0.0, 5.0.1, or 6.1.0 these resources include:
+          If using US Core 3.1.1, 4.0.0, or 6.1.0 these resources include:
 
           * “AllergyIntolerance”;
           * “CarePlan”;
@@ -532,11 +532,6 @@ procedure:
           * “Patient”;
           * “Procedure”; and
           * “Provenance”.
-
-          The following resources must also be supported if using US Core 5.0.1:
-          * “Encounter”;
-          * “RelatedPerson”; and
-          * “ServiceRequest”
 
           The following resources must also be supported if using US Core 6.1.0:
           * "Encounter"
@@ -554,7 +549,7 @@ procedure:
           associated with the profiles specified in the standard adopted in
           § 170.213 and implementation specification adopted in § 170.215(a)(2).
 
-          If using US Core 3.1.1, 4.0.0, 5.0.1, or 6.1.0 these resources include:
+          If using US Core 3.1.1, 4.0.0, or 6.1.0 these resources include:
 
           * “AllergyIntolerance”;
           * “CarePlan”;
@@ -571,11 +566,6 @@ procedure:
           * “Patient”;
           * “Procedure”; and
           * “Provenance”.
-
-          The following resources must also be supported if using US Core 5.0.1:
-          * “Encounter”;
-          * “RelatedPerson”; and
-          * “ServiceRequest”
 
           The following resources must also be supported if using US Core 6.1.0:
           * "Encounter"
@@ -815,8 +805,7 @@ procedure:
           * “smart_style_url” (to support “context-style” “SMART on FHIR® Core
             Capability” for EHR-Launch mode only).
 
-          Additionally, the following must be supported if using US Core 5.0.1
-          or 6.1.0:
+          Additionally, the following must be supported if using US Core 6.1.0:
           * “encounter” (to support "context-ehr-encounter" “SMART on FHIR®
             Capability”)
         TLV: |
@@ -841,8 +830,7 @@ procedure:
           * “smart_style_url” (to support “context-style” “SMART on FHIR® Core
             Capability” for EHR-Launch mode only).
 
-          Additionally, the following must be supported if using US Core 5.0.1
-          or 6.1.0:
+          Additionally, the following must be supported if using US Core 6.1.0:
           * “encounter” (to support"context-ehr-encounter" “SMART on FHIR®
             Capability”)
         inferno_supported: 'yes'
@@ -924,14 +912,14 @@ procedure:
           - 9.9.10
       - id: AUT-PAT-32
         SUT: |
-          [EHR-Launch] The following must be supported if using US Core 5.0.1 or
-          6.1.0: The health IT developer demonstrates the ability of the Health
+          [EHR-Launch] The following must be supported if using US Core 6.1.0:
+          The health IT developer demonstrates the ability of the Health
           IT Module to return an “Encounter” FHIR® resource that matches the
           encounter context provided in step AUT-PAT-9 of this section according
           to the implementation specification adopted in § 170.215(a)(2).
         TLV: |
-          [EHR-Launch] The following must be supported if using US Core 5.0.1 or
-          6.1.0: The tester verifies the ability of the Health IT Module to
+          [EHR-Launch] The following must be supported if using US Core 6.1.0:
+          The tester verifies the ability of the Health IT Module to
           return an “Encounter” FHIR® resource that matches the encounter
           context provided in step AUT-PAT-9 of this section according to the
           implementation specification adopted in § 170.215(a)(2).
@@ -1931,7 +1919,7 @@ procedure:
           * For coded data elements, including support for the
             “DataAbsentReason” Code System.
         inferno_supported: 'yes'
-        inferno_tests: 
+        inferno_tests:
           - 4.32.01 - 4.32.02
           - 5.34.01 - 5.34.02
           - 10.46.01 - 10.46.02


### PR DESCRIPTION
This PR fixes JIRA FI-2645 by removing US Core 5.0.1 from descirptions from 
* READ.me
* Bulk Data validation test 
* Test Procedure mapping