### PR TITLE
FI-2667: Bump validator version to 1.0.52

### DIFF
--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -29,7 +29,7 @@ services:
       - ./data/redis:/data
     command: redis-server --appendonly yes
   hl7_validator_service:
-    image: infernocommunity/inferno-resource-validator:1.0.51
+    image: infernocommunity/inferno-resource-validator:1.0.52
     environment:
       # Defines how long validator sessions last if unused, in minutes:
       # Negative values mean sessions never expire, 0 means sessions immediately expire

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -3,7 +3,7 @@ require_relative '../inferno/terminology/tasks/check_built_terminology'
 module ONCCertificationG10TestKit
   class ConfigurationChecker
     EXPECTED_VALIDATOR_VERSION = '2.3.2'.freeze
-    EXPECTED_HL7_VALIDATOR_VERSION = '"6.3.0"'.freeze
+    EXPECTED_HL7_VALIDATOR_VERSION = '"6.3.3"'.freeze
 
     def configuration_messages
       validator_version_message + terminology_messages + version_message


### PR DESCRIPTION
Just bumps the validator version to the latest, 1.0.52: https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/releases

The validator image is available on Docker Hub https://hub.docker.com/repository/docker/infernocommunity/inferno-resource-validator/general

Impacts:
- There should be no new validator errors compared to the previous version, for US Core 3, 4, or 6. 
- There should be better logging in the validator logs.