### PR TITLE
Add error filter for tx validator errors

### DIFF
--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -70,7 +70,8 @@ module ONCCertificationG10TestKit
       /\A\S+: \S+: The Coding provided \(\S*\) was not found in the value set/,
       /\A\S+: \S+: A definition for CodeSystem '.*' could not be found, so the code cannot be validated/,
       /\A\S+: \S+: URL value '.*' does not resolve/,
-      /\A\S+: \S+: .*\[No server available\]/  # Catch-all for certain errors when TX server is disabled
+      /\A\S+: \S+: .*\[No server available\]/,  # Catch-all for certain errors when TX server is disabled
+      %r{\A\S+: \S+: .*\[Error from http://tx.fhir.org/r4:} # Catch-all for TX server errors that slip through
     ].freeze
 
     def self.setup_validator(us_core_version_requirement) # rubocop:disable Metrics/CyclomaticComplexity


### PR DESCRIPTION
Quick fix for the tx.fhir.org validation errors that we have seen slip through, as in #523 and #524. Now any message containing `[Error from tx.fhir.org/r4:` will be ignored.

## Testing notes
Testing this is tricky since this error is flaky. I used https://mockoon.com/ to create a mock service that always returned a bad error, with the attached response. [validate.txt](https://github.com/user-attachments/files/16086942/validate.txt)  I got this response from validator.fhir.org using a DocumentReference with a bad mime type "junk/pdf". Note I replaced the sessionID field at the bottom with a mockoon template helper so the sessionID isn't consistent (the validator session startup job broke when every instance got back the same session ID)