### PR TITLE
FI-2838: Update patient context title and description

### DIFF
--- a/lib/onc_certification_g10_test_kit/patient_context_test.rb
+++ b/lib/onc_certification_g10_test_kit/patient_context_test.rb
@@ -1,9 +1,10 @@
 module ONCCertificationG10TestKit
   class PatientContextTest < Inferno::Test
-    title 'OAuth token exchange response body contains patient context and patient resource can be retrieved'
+    title 'Patient from launch context can be retrieved'
     description %(
       The `patient` field is a String value with a patient id, indicating that
-      the app was launched in the context of this FHIR Patient.
+      the app was launched in the context of this FHIR Patient. This test
+      verifies that the Patient resource with that id can be retrieved.
     )
     id :g10_patient_context
     input :patient_id, :url


### PR DESCRIPTION
The patient context test is run in the context of original access token exchanges, as well as token refreshes, but its title did not accurately describe its behavior when used in the context of a token refresh (see #522).

This branch updates the title and description to something which should be accurate in both circumstances.