### PR TITLE
FI-2981: Update matrix generation for deeply nested tests

### DIFF
--- a/lib/onc_certification_g10_test_kit/onc_program_procedure.yml
+++ b/lib/onc_certification_g10_test_kit/onc_program_procedure.yml
@@ -516,8 +516,8 @@ procedure:
           - 1.4.02
           - 3.4.04
           - 9.13.2.02
-          # - 9.14.1.1.2.08
-          # - 9.14.2.1.2.08
+          - 9.14.1.1.2.08
+          - 9.14.2.1.2.08
         inferno_notes: |
           This step refers to only the receipt of these scopes, which is covered in
           Inferno in one step in each the EHR and Standalone launch cases.  However,

--- a/lib/onc_certification_g10_test_kit/tasks/generate_matrix.rb
+++ b/lib/onc_certification_g10_test_kit/tasks/generate_matrix.rb
@@ -50,6 +50,10 @@ module ONCCertificationG10TestKit
         workbook.write(FILE_NAME)
       end
 
+      def all_descendant_tests(runnable)
+        runnable.tests + runnable.groups.flat_map { |group| all_descendant_tests(group) }
+      end
+
       def generate_matrix_worksheet # rubocop:disable Metrics/CyclomaticComplexity
         matrix_worksheet = workbook.worksheets[0]
         matrix_worksheet.sheet_name = 'Matrix'
@@ -86,17 +90,8 @@ module ONCCertificationG10TestKit
             matrix_worksheet.change_column_border(col, :right, 'thin')
             matrix_worksheet.change_column_border_color(col, :right, '666666')
 
-            test_case.tests.each do |test|
-              # tests << { test_case: test_case, test: test }
-              # full_test_id = "#{test_case.prefix}#{test.id}"
-              column_map[test.short_id] = col
-            end
+            all_descendant_tests(test_case).each { |test| column_map[test.short_id] = col }
 
-            test_case.groups.each do |nested_group|
-              nested_group.tests.each do |test|
-                column_map[test.short_id] = col
-              end
-            end
             col += 1
           end
         end

--- a/lib/onc_certification_g10_test_kit/tasks/generate_matrix.rb
+++ b/lib/onc_certification_g10_test_kit/tasks/generate_matrix.rb
@@ -209,26 +209,26 @@ module ONCCertificationG10TestKit
         workbook.worksheets[2]
       end
 
-      def columns
+      def columns # rubocop:disable Metrics/CyclomaticComplexity
         @columns ||= [
           ['', 3, ->(_test) { '' }],
           ['', 3, ->(_test) { '' }],
           ['Inferno Test ID', 22, ->(test) { test.short_id.to_s }],
           ['Inferno Test Name', 65, ->(test) { test.title }],
           ['Inferno Test Description', 65, lambda do |test|
-             description = test.description || ''
-             natural_indent =
-               description
-                 .lines
-                 .collect { |l| l.index(/[^ ]/) }
-                 .select { |l| !l.nil? && l.positive? }
-                 .min || 0
-             description.lines.map { |l| l[natural_indent..] || "\n" }.join.strip
-           end],
+                                             description = test.description || ''
+                                             natural_indent =
+                                               description
+                                                 .lines
+                                                 .collect { |l| l.index(/[^ ]/) }
+                                                 .select { |l| !l.nil? && l.positive? }
+                                                 .min || 0
+                                             description.lines.map { |l| l[natural_indent..] || "\n" }.join.strip
+                                           end],
           ['Test Procedure Steps', 30, ->(test) { inferno_to_procedure_map[test.short_id].join(', ') }],
           ['Standard Version Filter', 30, lambda do |test|
-             applicable_options(test).map(&:value).uniq.join(', ')
-           end]
+                                            applicable_options(test).map(&:value).uniq.join(', ')
+                                          end]
         ]
       end
 


### PR DESCRIPTION
This branch updates the matrix generation to handle tests at different levels of nesting.

If you run `bundle exec rake g10_test_kit:generate_matrix` and examine the newly generated matrix, you should see:

- On the "Matrix" sheet, `9.14` should be identified as satisfying `AUT-PAT-28`.
- On the "Inferno Tests" sheet, all of the tests under `9.14` should appear.

This branch is on top of #537 because that PR contains the deeply nested tests which this change supports.