### PR TITLE
FI-2950: Improve test description

### DIFF
--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -348,11 +348,19 @@ module ONCCertificationG10TestKit
       title 'Additional Authorization Tests'
       id 'Group06'
       description %(
-        Not all requirements that need to be tested fit within the previous
-        scenarios. The tests contained in this section addresses remaining
-        testing requirements. Each of these tests need to be run independently.
-        Please read the instructions for each in the 'About' section, as they
-        may require special setup on the part of the tester.
+        The (g)(10) Standardized Test Suite attempts to minimize effort required
+        by testers by creating scenarios that validate as many requirements as
+        possible with just a handful of SMART App Launches.  However, not all
+        SMART App Launch and (g)(10) Standardized API criterion requirements
+        that need to be verified fit within the first few test scenarios in this
+        suite.
+
+        The scenarios contained in this section verify remaining testing
+        requirements for the (g)(10) Standardized API criterion relevant to
+        the SMART App Launch implementation specification. Each of these scenarios
+        need to be run independently.  Please read the instructions for each in
+        the 'About' section, as they may require special setup on the part of
+        the tester.
       )
 
       default_redirect_message_proc = lambda do |auth_url|

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -269,10 +269,10 @@ module ONCCertificationG10TestKit
       be run out of order to support testing during development or certification
       preparation.  Some scenarios depend on data collected during previous
       scenarios to function.  In these cases, the scenario description describes
-      these dependendies.
+      these dependencies.
 
       The best way to learn about how to use these tests is the
-      [(g)(10) Standadrized API Test Kit walkthrough](https://github.com/onc-healthit/onc-certification-g10-test-kit/wiki/Walkthrough),
+      [(g)(10) Standardized API Test Kit walkthrough](https://github.com/onc-healthit/onc-certification-g10-test-kit/wiki/Walkthrough),
       which demonstrates the tests running against a simulated system.
 
       The first three scenarios require the system under test to demonstrate
@@ -297,7 +297,7 @@ module ONCCertificationG10TestKit
 
       * `#{Inferno::Application[:base_url]}/custom/g10_certification/.well-known/jwks.json`
 
-      Systems must pass all tests in order to qualify for ONC certification.
+      Systems must pass all tests to qualify for ONC certification.
     )
 
     suite_summary %(

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -257,13 +257,37 @@ module ONCCertificationG10TestKit
     )
 
     description %(
-      The ONC Certification (g)(10) Standardized API Test Kit is a testing tool for
-      Health Level 7 (HL7®) Fast Healthcare Interoperability Resources (FHIR®)
-      services seeking to meet the requirements of the Standardized API for
-      Patient and Population Services criterion § 170.315(g)(10) in the ONC Certification Program.
+      The ONC Certification (g)(10) Standardized API Test Suite is a testing
+      tool for Health Level 7 (HL7®) Fast Healthcare Interoperability Resources
+      (FHIR®) services seeking to meet the requirements of the Standardized API
+      for Patient and Population Services criterion § 170.315(g)(10) in the ONC
+      Certification Program.
 
-      To get started, please first register the Inferno client as a SMART App
-      with the following information:
+      This test suite is organized into testing scenarios that in sum cover all
+      requirements within the § 170.315(g)(10) certification criterion.  The
+      scenarios are intended to be run in order during certification, but can
+      be run out of order to support testing during development or certification
+      preparation.  Some scenarios depend on data collected during previous
+      scenarios to function.  In these cases, the scenario description describes
+      these dependendies.
+
+      The best way to learn about how to use these tests is the
+      [(g)(10) Standadrized API Test Kit walkthrough](https://github.com/onc-healthit/onc-certification-g10-test-kit/wiki/Walkthrough),
+      which demonstrates the tests running against a simulated system.
+
+      The first three scenarios require the system under test to demonstrate
+      basic SMART App Launch functionality.  The fourth uses a valid token
+      provided during earlier tests to verify support for the Single Patient API
+      as described in the criterion.  The fifth verifies support for the Multi
+      Patient API, including Backend Services for authorization.  Not all
+      authorization-related requirements are verified in the first three
+      scenarios, and the 'Additional Authorization Tests' verify these
+      additional requirements.  The last scenario contains a list of
+      'attestations' and 'visual inspections' for requirements that could not
+      be verified through automated testing.
+
+      To get started with the first group of scenarios, please first register the
+      Inferno client as a SMART App with the following information:
 
       * SMART Launch URI: `#{SMARTAppLaunch::AppLaunchTest.config.options[:launch_uri]}`
       * OAuth Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`

--- a/lib/onc_certification_g10_test_kit/multi_patient_api_stu1.rb
+++ b/lib/onc_certification_g10_test_kit/multi_patient_api_stu1.rb
@@ -21,20 +21,25 @@ module ONCCertificationG10TestKit
     )
 
     description %(
-      Demonstrate the ability to export clinical data for multiple patients in a
-      group using [FHIR Bulk Data Access
-      IG](http://hl7.org/fhir/uv/bulkdata/STU1.0.1/). This test uses [Backend
-      Services
+      This scenario verifies the ability of the system to export clinical data
+      for multiple patients in a group using [FHIR Bulk Data Access
+      IG](http://hl7.org/fhir/uv/bulkdata/STU1.0.1/). This scenario uses
+      [Backend Services
       Authorization](http://hl7.org/fhir/uv/bulkdata/STU1.0.1/authorization/index.html)
       to obtain an access token from the server. After authorization, a group
-      level bulk data export request is initialized. Finally, this test reads
-      exported NDJSON files from the server and validates the resources in each
-      file. To run the test successfully, the selected group export is required
-      to have resources conforming to every profile mapped to [USCDI data
+      level bulk data export request is initialized. Finally, this scenario
+      reads exported NDJSON files from the server and validates the resources in
+      each file. To run the test successfully, the selected group export is
+      required to have resources conforming to every profile mapped to [USCDI
+      data
       elements](https://www.healthit.gov/isa/us-core-data-interoperability-uscdi).
       Additionally, it is expected the server will provide Encounter, Location,
       Organization, and Practitioner resources as they are referenced as must
       support elements in required resources.
+
+      Prior to executing this scenario, register Inferno with the following JWK Set Url:
+
+      * `#{Inferno::Application[:base_url]}/custom/g10_certification/.well-known/jwks.json`
     )
     id :multi_patient_api
     run_as_group

--- a/lib/onc_certification_g10_test_kit/multi_patient_api_stu2.rb
+++ b/lib/onc_certification_g10_test_kit/multi_patient_api_stu2.rb
@@ -21,20 +21,25 @@ module ONCCertificationG10TestKit
     )
 
     description %(
-      Demonstrate the ability to export clinical data for multiple patients in a
-      group using [FHIR Bulk Data Access
-      IG](https://hl7.org/fhir/uv/bulkdata/STU2/). This test uses [Backend
+      This scenario verifies the ability of the system to export clinical data
+      for multiple patients in a group using [FHIR Bulk Data Access
+      IG](https://hl7.org/fhir/uv/bulkdata/STU2/). This scenario uses [Backend
       Services
       Authorization](http://www.hl7.org/fhir/smart-app-launch/backend-services.html)
       to obtain an access token from the server. After authorization, a group
-      level bulk data export request is initialized. Finally, this test reads
-      exported NDJSON files from the server and validates the resources in each
-      file. To run the test successfully, the selected group export is required
-      to have resources conforming to every profile mapped to [USCDI data
+      level bulk data export request is initialized. Finally, this scenario
+      reads exported NDJSON files from the server and validates the resources in
+      each file. To run the test successfully, the selected group export is
+      required to have resources conforming to every profile mapped to [USCDI
+      data
       elements](https://www.healthit.gov/isa/us-core-data-interoperability-uscdi).
       Additionally, it is expected the server will provide Encounter, Location,
       Organization, and Practitioner resources as they are referenced as must
       support elements in required resources.
+
+      Prior to executing this scenario, register Inferno with the following JWK Set Url:
+
+      * `#{Inferno::Application[:base_url]}/custom/g10_certification/.well-known/jwks.json`
     )
     id :multi_patient_api_stu2
     run_as_group

--- a/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
@@ -8,8 +8,13 @@ module ONCCertificationG10TestKit
     title 'Single Patient API (US Core 3.1.1)'
     short_title 'Single Patient API'
     description %(
+      This scenario verifies the ability of a system to provide a 'Single Patient API'
+      as described in the (g)(10) Standardized API certification criterion.
+      Prior to running this scenario, systems must recieve a verified access token
+      from one of the previous SMART App Launch scenarios.
+
       For each of the relevant USCDI data elements provided in the
-      CapabilityStatement, this test executes the [required supported
+      CapabilityStatement, this scenario executes the [required supported
       searches](http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html)
       as defined by the US Core Implementation Guide v3.1.1.
 

--- a/lib/onc_certification_g10_test_kit/single_patient_us_core_4_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_us_core_4_api_group.rb
@@ -6,8 +6,13 @@ module ONCCertificationG10TestKit
     title 'Single Patient API (US Core 4.0.0)'
     short_title 'Single Patient API'
     description %(
+      This scenario verifies the ability of a system to provide a 'Single Patient API'
+      as described in the (g)(10) Standardized API certification criterion.
+      Prior to running this scenario, systems must recieve a verified access token
+      from one of the previous SMART App Launch scenarios.
+
       For each of the relevant USCDI data elements provided in the
-      CapabilityStatement, this test executes the [required supported
+      CapabilityStatement, this scenario executes the [required supported
       searches](http://hl7.org/fhir/us/core/STU4/CapabilityStatement-us-core-server.html)
       as defined by the US Core Implementation Guide v4.0.0.
 

--- a/lib/onc_certification_g10_test_kit/single_patient_us_core_6_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_us_core_6_api_group.rb
@@ -6,8 +6,13 @@ module ONCCertificationG10TestKit
     title 'Single Patient API (US Core 6.1.0)'
     short_title 'Single Patient API'
     description %(
+      This scenario verifies the ability of a system to provide a 'Single Patient API'
+      as described in the (g)(10) Standardized API certification criterion.
+      Prior to running this scenario, systems must recieve a verified access token
+      from one of the previous SMART App Launch scenarios.
+
       For each of the relevant USCDI data elements provided in the
-      CapabilityStatement, this test executes the [required supported
+      CapabilityStatement, this scenario executes the [required supported
       searches](http://hl7.org/fhir/us/core/STU6.1/CapabilityStatement-us-core-server.html)
       as defined by the US Core Implementation Guide v6.1.0.
 

--- a/lib/onc_certification_g10_test_kit/smart_app_launch_invalid_aud_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_app_launch_invalid_aud_group.rb
@@ -8,25 +8,24 @@ module ONCCertificationG10TestKit
       * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
     )
     description %(
-      # Background
+      This scenario verifies that a SMART Launch Sequence, specifically the
+      Standalone Launch Sequence, does not succeed in the case where the client
+      sends an invalid FHIR server as the `aud` parameter during launch. This
+      must fail to ensure that a genuine bearer token is not leaked to a
+      counterfit resource server.
 
-      The Invalid AUD Sequence verifies that a SMART Launch Sequence,
-      specifically the Standalone Launch Sequence, does not work in the case
-      where the client sends an invalid FHIR server as the `aud` parameter
-      during launch. This must fail to ensure that a genuine bearer token is not
-      leaked to a counterfit resource server.
-
-      This test is not included as part of a regular SMART Launch Sequence
-      because it requires the browser of the user to be redirected to the
-      authorization service, and there is no expectation that the authorization
-      service redirects the user back to Inferno with an error message. The only
-      requirement is that Inferno is not granted a code to exchange for a valid
-      access token. Since this is a special case, it is tested independently in
-      a separate sequence.
+      This test is not included in earlier scenarios because it requires the
+      browser of the user to be redirected to the authorization service, and
+      there is no expectation that the authorization service redirects the user
+      back to Inferno with an error message. The only requirement is that
+      Inferno is not granted a code to exchange for a valid access token. Since
+      this is a special case, it is tested independently in a separate sequence.
 
       Note that this test will launch a new browser window. The user is required
       to 'Attest' in the Inferno user interface after the launch does not
       succeed, if the server does not return an error code.
+
+      The following implementation specifications are relevant to this scenario:
 
       * [Standalone Launch Sequence
         (STU1)](http://hl7.org/fhir/smart-app-launch/1.0.0/index.html#standalone-launch-sequence)

--- a/lib/onc_certification_g10_test_kit/smart_asymmetric_launch_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_asymmetric_launch_group.rb
@@ -6,8 +6,6 @@ module ONCCertificationG10TestKit
     title 'Asymmetric Client Standalone Launch'
     short_title 'Asymmetric Client Launch'
     description %(
-      # Background
-
       The [Standalone
       Launch Sequence](http://hl7.org/fhir/smart-app-launch/STU2/app-launch.html#launch-app-standalone-launch)
       allows an app, like Inferno, to be launched independent of an
@@ -19,11 +17,10 @@ module ONCCertificationG10TestKit
 
       These tests specifically verify a system's support for [confidential
       asymmetric client
-      authentication](https://hl7.org/fhir/smart-app-launch/STU2/client-confidential-asymmetric.html).
+      authentication](https://hl7.org/fhir/smart-app-launch/STU2/client-confidential-asymmetric.html),
+      which is not verified in earlier scenarios.
 
-      # Test Methodology
-
-      Inferno will redirect the user to the the authorization endpoint so that
+      In this scenario, Inferno will redirect the user to the the authorization endpoint so that
       they may provide any required credentials and authorize the application.
       Upon successful authorization, Inferno will exchange the authorization
       code provided for an access token.

--- a/lib/onc_certification_g10_test_kit/smart_ehr_patient_launch_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_patient_launch_group.rb
@@ -4,10 +4,10 @@ module ONCCertificationG10TestKit
   class SMARTEHRPatientLaunchGroup < SMARTAppLaunch::EHRLaunchGroup
     title 'EHR Launch with Patient Scopes'
     description %(
-      # Background
       Systems are required to support the `permission-patient` capability as
       part of the [Clinician Access for EHR Launch Capability
       Set.](http://hl7.org/fhir/smart-app-launch/1.0.0/conformance/index.html#clinician-access-for-ehr-launch)
+      Previous scenarios do not verify this specific combination of capabilies.
 
       Additionally, if an application launched from an EHR requests and is
       granted a clinical scope restricted to a single patient, the EHR SHALL
@@ -19,9 +19,7 @@ module ONCCertificationG10TestKit
       * Launch URI: `#{SMARTAppLaunch::AppLaunchTest.config.options[:launch_uri]}`
       * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
 
-      # Test Methodology
-
-      Inferno will attempt an EHR Launch with a clinical scope restricted to a
+      In this scenario, Inferno will attempt an EHR Launch with a clinical scope restricted to a
       single patient and verify that a patient-level scope is granted and a
       patient id is received.
 

--- a/lib/onc_certification_g10_test_kit/smart_ehr_patient_launch_group_stu2.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_patient_launch_group_stu2.rb
@@ -4,10 +4,10 @@ module ONCCertificationG10TestKit
   class SMARTEHRPatientLaunchGroupSTU2 < SMARTAppLaunch::EHRLaunchGroupSTU2
     title 'EHR Launch with Patient Scopes'
     description %(
-      # Background
       Systems are required to support the `permission-patient` capability as
       part of the [Clinician Access for EHR Launch Capability
       Set.](http://hl7.org/fhir/smart-app-launch/STU2/conformance.html#clinician-access-for-ehr-launch)
+      Previous scenarios do not verify this specific combination of capabilies.
 
       Additionally, if an application launched from an EHR requests and is
       granted a clinical scope restricted to a single patient, the EHR SHALL
@@ -19,9 +19,7 @@ module ONCCertificationG10TestKit
       * Launch URI: `#{SMARTAppLaunch::AppLaunchTest.config.options[:launch_uri]}`
       * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
 
-      # Test Methodology
-
-      Inferno will attempt an EHR Launch with a clinical scope restricted to a
+      In this scenario, Inferno will attempt an EHR Launch with a clinical scope restricted to a
       single patient and verify that a patient-level scope is granted and a
       patient id is received.
 

--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -26,18 +26,32 @@ module ONCCertificationG10TestKit
     )
 
     description %(
-      Demonstrate the ability to perform an EHR launch to a SMART on FHIR
+      This scenario verifies the ability of a system to perform a single EHR
+      Launch.  Specifically, this scenario performs an EHR launch to a SMART on FHIR
       confidential client with patient context, refresh token, OpenID Connect
       (OIDC) identity token, and (SMART v2 only) use the POST HTTP method for
-      code exchange. After launch, a simple Patient resource read is performed
-      on the patient in context. The access token is then refreshed, and the
-      Patient resource is read using the new access token to ensure that the
-      refresh was successful. Finally, the authentication information provided
-      by OpenID Connect is decoded and validated.
+      code exchange.
+
+      After launch, a simple Patient resource read is performed on the patient
+      in context. The access token is then refreshed, and the Patient resource
+      is read using the new access token to ensure that the refresh was
+      successful. Finally, the authentication information provided by OpenID
+      Connect is decoded and validated.
+
+      Prior to running this scenario, register Inferno as an EHR-launched confidential
+      client with the following information:
+
+      Prior to running this test, register Inferno as an EHR-launched
+      application using the following information:
+
+      * Launch URI: `#{SMARTAppLaunch::AppLaunchTest.config.options[:launch_uri]}`
+      * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
 
       For EHRs that use Internet Explorer 11 to display embedded apps,
       please review [instructions on how to complete the EHR Practitioner App
       test](https://github.com/onc-healthit/onc-certification-g10-test-kit/wiki/Completing-EHR-Practitioner-App-test-in-Internet-Explorer/).
+
+      The following implementation specifications are relevant to this scenario:
 
       * [SMART on FHIR
         (STU1)](http://www.hl7.org/fhir/smart-app-launch/1.0.0/)

--- a/lib/onc_certification_g10_test_kit/smart_fine_grained_scopes_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_fine_grained_scopes_group.rb
@@ -4,11 +4,15 @@ module ONCCertificationG10TestKit
     short_title 'SMART Launch with Fine-Grained Scopes'
 
     input_instructions %(
-      Register Inferno as a standalone application using the following information:
+      If necessary, register Inferno as a standalone application using the following information:
 
       * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
 
-      Each group requires a separate set of granular scopes to be granted:
+      Inferno may be registered multiple times with different `client_ids`, or this
+      may reuse a single registration of Inferno.`
+
+      This test will perform two launches, with each launch requiring a separate
+      separate set of finer-grained scopes to be granted:
 
       Group 1:
       * `Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|encounter-diagnosis`
@@ -24,9 +28,20 @@ module ONCCertificationG10TestKit
     )
 
     description <<~DESCRIPTION
-      This scenario verifies that the system under test supports:
 
-      > SMART v2 scope syntax for patient-level and user-level scopes to support
+      As finalized in the [HTI-1 Final Rule](https://www.federalregister.gov/d/2023-28857/p-1250), Health IT Modules are
+      required to support SMART App Launch v2.0.0 "Finer-grained resource
+      constraints using search parameters" for the "category" parameter for the
+      Condition resource with Condition sub-resources Encounter Diagnosis, Problem
+      List, and Health Concern, and the Observation resource with Observation
+      sub-resources Clinical Test, Laboratory, Social History, SDOH, Survey, and
+      Vital Signs.
+
+      This is also reflected in the (g)(10) Standardized API for patient and
+      populations [Test
+      Procedure](https://www.healthit.gov/test-method/standardized-api-patient-and-population-services#test_procedure):
+
+      > [AUT-PAT-28] SMART v2 scope syntax for patient-level and user-level scopes to support
         the “permission-v2” “SMART on FHIR® Capability”, including support for
         finer-grained resource constraints using search parameters according to
         section 3.0.2.3 of the implementation specification at § 170.215(c)(2) for
@@ -36,15 +51,19 @@ module ONCCertificationG10TestKit
         sub-resources Clinical Test, Laboratory, Social History, SDOH, Survey, and
         Vital Signs
 
-      Prior to running these tests, first run the Single Patient API tests using
-      resource-level scopes. This group contains two sets of granular scope
-      tests, each of which includes a SMART Standalone Launch followed by FHIR
-      API tests. The app launches require that a particular subset of the
-      required granular scopes be granted. The FHIR API tests then repeat all of
-      the queries from the original Single Patient API tests that were run using
-      resource-level scopes, and verify that only resources matching the current
-      granular scopes are returned. Each group requires a separate set of
-      granular scopes to be granted:
+      Prior to running this scenario, first run the Single Patient API tests using
+      resource-level scopes, as this scenario uses content saved from that scenario
+      as a baseline for comparison when finer-grained scopes are granted.
+
+      This scenario contains two groups of finer-grained scope tests, each of
+      which includes a SMART Standalone Launch that requests a subset of
+      finer-grained scopes, followed by FHIR API requests to verify that scopes
+      are appropriately granted. The app launches require that the subset of the
+      requested finer-grained scopes are granted by the user. The FHIR API tests then repeat all
+      of the queries from the original Single Patient API tests that were run
+      using resource-level scopes, and verify that only resources matching the
+      current finer-grained scopes are returned. Each group requires a separate
+      set of finer-grained scopes to be granted:
 
       Group 1:
       * `Condition.rs?category=http://terminology.hl7.org/CodeSystem/condition-category|encounter-diagnosis`
@@ -58,8 +77,15 @@ module ONCCertificationG10TestKit
       * `Observation.rs?category=http://terminology.hl7.org/CodeSystem/observation-category|survey`
       * `Observation.rs?category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh`
 
-      [Finer-grained resource constraints using search
-      parameters](https://hl7.org/fhir/smart-app-launch/STU2/scopes-and-launch-context.html#finer-grained-resource-constraints-using-search-parameters)
+      Note that Inferno will only request the finer grained scopes in each case,
+      but the system under test can display more scopes to the tester during
+      authorization.  In this case, it is expected that the tester will only
+      approve the appropriate scopes in each group as described above.
+
+      For more information, please refer to [finer-grained resource constraints
+      using search
+      parameters](https://hl7.org/fhir/smart-app-launch/STU2/scopes-and-launch-context.html#finer-grained-resource-constraints-using-search-parameters).
+
     DESCRIPTION
 
     id :g10_smart_fine_grained_scopes
@@ -68,7 +94,7 @@ module ONCCertificationG10TestKit
 
     children.each(&:run_as_group)
 
-    # Replace generic granular scope auth group with which allows standalone or
+    # Replace generic finer-grained scope auth group with which allows standalone or
     # ehr launch with just the standalone launch group
     granular_scopes_group1 = children.first
     granular_scopes_group1.children[0] = granular_scopes_group1.children.first.children.first

--- a/lib/onc_certification_g10_test_kit/smart_fine_grained_scopes_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_fine_grained_scopes_group.rb
@@ -24,7 +24,7 @@ module ONCCertificationG10TestKit
     )
 
     description <<~DESCRIPTION
-      These tests verify that the system under test supports:
+      This scenario verifies that the system under test supports:
 
       > SMART v2 scope syntax for patient-level and user-level scopes to support
         the “permission-v2” “SMART on FHIR® Capability”, including support for

--- a/lib/onc_certification_g10_test_kit/smart_granular_scope_selection_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_granular_scope_selection_group.rb
@@ -7,15 +7,34 @@ module ONCCertificationG10TestKit
     short_title 'SMART Granular Scope Selection'
     id :g10_smart_granular_scope_selection
 
-    description <<~DESCRIPTION
-      These tests verify that when resource-level scopes are requested for
-      Condition and Observation resources, the user is presented with the option
-      of approving sub-resource scopes rather than the resource-level scope.
+    input_instructions %(
+      If necessary, register Inferno as a standalone application using the following information:
 
-      The tests request v2 resource-level Condition and Observation scopes. In
-      each instance, the user must unselect the resource-level scopes and
-      instead approve sub-resource scopes for Condition and Observation. It is
-      also required that a resource-level Patient scope be granted.
+      * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
+
+      Once the test is running, Inferno will perform a launch.  The tester must grant
+      a sub-resource scope for each Conditoin and Observation, instead of granting
+      access to all Condition and Observation resources:
+
+      * “Condition” sub-resource scopes “Encounter Diagnosis”, “Problem List”,
+          and “Health Concern”
+      * “Observation” sub-resource scopes “Clinical Test”, “Laboratory”,
+          “Social History”, “SDOH”, “Survey”, and “Vital Signs”
+
+      Additionally, please grant access to the Patient scope.
+
+    )
+
+
+    description <<~DESCRIPTION
+      This scenario verifies that when resource-level scopes are requested for
+      Condition and Observation resources, the user is presented with the option
+      of granting sub-resource scopes instead of the requested resource-level scope if desired.
+
+      This scenario verifies that system behavior is consistent with the
+      following clarification provided in the §170.315(g)(10) Standardized API
+      for patient and population services [Certification Companion
+      Guide](https://www.healthit.gov/test-method/standardized-api-patient-and-population-services#ccg):
 
       > As part of supporting the SMART App Launch “permission-v2” capability
         for the purposes of certification, if an app requests authorization for
@@ -31,6 +50,17 @@ module ONCCertificationG10TestKit
       > * “Observation” sub-resource scopes “Clinical Test”, “Laboratory”,
           “Social History”, “SDOH”, “Survey”, and “Vital Signs” if an
           “Observation” resource level scope is requested
+
+      The tests request SMART App Launch v2 resource-level Condition and
+      Observation scopes. In each instance, the user must not grant the
+      resource-level scopes and instead grant any valid sub-resource scope for
+      Condition and Observation listed above. This scenario also requires that a
+      resource-level Patient scope be granted.
+
+      This scenario only verifies that sub-resource scopes are granted as returned by the
+      authorization system during the SMART App Launch process, and does not
+      attempt to access resources to verify accuracy of the granted scopes.
+
     DESCRIPTION
 
     run_as_group

--- a/lib/onc_certification_g10_test_kit/smart_granular_scope_selection_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_granular_scope_selection_group.rb
@@ -25,7 +25,6 @@ module ONCCertificationG10TestKit
 
     )
 
-
     description <<~DESCRIPTION
       This scenario verifies that when resource-level scopes are requested for
       Condition and Observation resources, the user is presented with the option

--- a/lib/onc_certification_g10_test_kit/smart_invalid_pkce_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_invalid_pkce_group.rb
@@ -49,13 +49,12 @@ module ONCCertificationG10TestKit
       * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
     )
     description %(
-      # Background
-
-      The #{title} Group verifies that a SMART Launch Sequence, specifically the
+      This scenario verifies that a SMART Launch Sequence, specifically the
       [Standalone
       Launch](http://hl7.org/fhir/smart-app-launch/STU2/app-launch.html#launch-app-standalone-launch)
-      Sequence, verifies that servers properly support PKCE.  It does this by ensuring the launch fails
-      in the case where the client sends an invalid PKCE `code_verifier`.
+      Sequence, verifies that servers properly support PKCE.  It does this by
+      ensuring the launch fails in the case where the client sends an invalid
+      PKCE `code_verifier`.
 
       This group performs four launches with various forms of an invalid `code_verifier`
       (e.g. incorrect `code_verifier`, blank `code_identifier`) and verifies that these do

--- a/lib/onc_certification_g10_test_kit/smart_invalid_token_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_invalid_token_group.rb
@@ -8,18 +8,16 @@ module ONCCertificationG10TestKit
       * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
     )
     description %(
-      # Background
-
-      The Invalid Access Token Request Sequence verifies that a SMART Launch
+      This scenario verifies that a SMART Launch
       Sequence, specifically the [Standalone
-      Launch](http://hl7.org/fhir/smart-app-launch/1.0.0/index.html#standalone-launch-sequence)
-      Sequence, does not work in the case where the client sends an invalid
+      Launch](http://hl7.org/fhir/smart-app-launch/STU2/app-launch.html#launch-app-standalone-launch)
+      Sequence, does not succeed in the case where the client sends an invalid
       Authorization code or client ID during the code exchange step. This must
       not result in a successful launch.
 
-      This test is not included as part of a regular SMART Launch Sequence
-      because some servers may not accept an authorization code after it has
-      been used unsuccessfully in this manner.
+      This test is not included as part of earlier scenarios because some
+      servers may not accept an authorization code after it has been used
+      unsuccessfully in this manner.
     )
     id :g10_smart_invalid_token_request
     run_as_group

--- a/lib/onc_certification_g10_test_kit/smart_invalid_token_group_stu2.rb
+++ b/lib/onc_certification_g10_test_kit/smart_invalid_token_group_stu2.rb
@@ -8,18 +8,16 @@ module ONCCertificationG10TestKit
       * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
     )
     description %(
-      # Background
-
-      The Invalid Access Token Request Sequence verifies that a SMART Launch
+      This scenario verifies that a SMART Launch
       Sequence, specifically the [Standalone
       Launch](http://hl7.org/fhir/smart-app-launch/STU2/app-launch.html#launch-app-standalone-launch)
-      Sequence, does not work in the case where the client sends an invalid
+      Sequence, does not succeed in the case where the client sends an invalid
       Authorization code or client ID during the code exchange step. This must
       not result in a successful launch.
 
-      This test is not included as part of a regular SMART Launch Sequence
-      because some servers may not accept an authorization code after it has
-      been used unsuccessfully in this manner.
+      This test is not included as part of earlier scenarios because some
+      servers may not accept an authorization code after it has been used
+      unsuccessfully in this manner.
     )
     id :g10_smart_invalid_token_request_stu2
     run_as_group

--- a/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_limited_app_group.rb
@@ -9,8 +9,8 @@ module ONCCertificationG10TestKit
     short_title 'Limited Access App'
 
     input_instructions %(
-      The purpose of this test is to demonstrate that app users can restrict
-      access granted to apps to a limited number of resources. Enter which
+      The purpose of this test is to verify that patient app users can restrict
+      access granted to apps to a limited number of resources Enter which
       resources the user will grant access to below, and during the launch
       process only grant access to those resources. Inferno will verify that
       access granted matches these expectations.
@@ -20,13 +20,15 @@ module ONCCertificationG10TestKit
     )
 
     description %(
-      This scenario demonstrates the ability to perform a Patient Standalone
+      This scenario verifies the ability of a system to perform a Patient Standalone
       Launch to a SMART on FHIR confidential client with limited access granted
       to the app based on user input. The tester is expected to grant the
       application access to a subset of desired resource types. The launch is
       performed using the same app configuration as in the Standalone Patient
       App test, demonstrating that the user has control over what scopes are
       granted to the app as required in the (g)(10) Standardized API criterion.
+
+      The following implementation specifications are relevant to this scenario:
 
       * [SMART on FHIR
         (STU1)](http://www.hl7.org/fhir/smart-app-launch/1.0.0/)

--- a/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group.rb
@@ -13,23 +13,21 @@ module ONCCertificationG10TestKit
       (offline_access), and patient context (launch/patient) are required.
     )
     description %(
-      # Background
 
-      The [Standalone
-      Launch](http://hl7.org/fhir/smart-app-launch/1.0.0/index.html#standalone-launch-sequence)
-      Sequence allows an app, like Inferno, to be launched independent of an
-      existing EHR session. It is one of the two launch methods described in
-      the SMART App Launch Framework alongside EHR Launch. The app will
-      request authorization for the provided scope from the authorization
-      endpoint, ultimately receiving an authorization token which can be
-      used to gain access to resources on the FHIR server.
+      This scenario verifies the ability of systems to support public clients
+      as described in the SMART App Launch implementation specification.  Previous
+      scenarios have not required the system under test to demonstrate this
+      specific type of SMART App Launch client.
 
-      # Test Methodology
+      Prior to executing this test, register Inferno as a public standalone
+      application using the following information:
 
-      Inferno will redirect the user to the the authorization endpoint so
-      that they may provide any required credentials and authorize the
-      application. Upon successful authorization, Inferno will exchange the
-      authorization code provided for an access token.
+      * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
+
+      Inferno will act as a public client redirect the tester to the the
+      authorization endpoint so that they may provide any required credentials
+      and authorize the application. Upon successful authorization, Inferno will
+      exchange the authorization code provided for an access token.
 
       For more information on the #{title}:
 

--- a/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group_stu2.rb
+++ b/lib/onc_certification_g10_test_kit/smart_public_standalone_launch_group_stu2.rb
@@ -12,6 +12,27 @@ module ONCCertificationG10TestKit
       fhirUser), refresh tokens (offline_access), and patient context
       (launch/patient) are required.
     )
+    description %(
+
+      This scenario verifies the ability of systems to support public clients
+      as described in the SMART App Launch implementation specification.  Previous
+      scenarios have not required the system under test to demonstrate this
+      specific type of SMART App Launch client.
+
+      Prior to executing this test, register Inferno as a public standalone
+      application using the following information:
+
+      * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
+
+      Inferno will act as a public client redirect the tester to the the
+      authorization endpoint so that they may provide any required credentials
+      and authorize the application. Upon successful authorization, Inferno will
+      exchange the authorization code provided for an access token.
+
+      For more information on the #{title}:
+
+      * [Standalone Launch Sequence](http://hl7.org/fhir/smart-app-launch/1.0.0/index.html#standalone-launch-sequence)
+    )
     id :g10_public_standalone_launch_stu2
     run_as_group
 

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -24,16 +24,25 @@ module ONCCertificationG10TestKit
     )
 
     description %(
-        This scenario demonstrates the ability of a system to perform a Patient
+        This scenario verifies the ability of a system to perform a single
+        SMART App Launch.  Specifically, this scenario performs a Patient
         Standalone Launch to a SMART on FHIR confidential client with a patient
         context, refresh token, OpenID Connect (OIDC) identity token, and use
-        the GET HTTP method for code exchange. After launch, a simple Patient
-        resource read is performed on the patient in context. The access token
-        is then refreshed, and the Patient resource is read using the new access
-        token to ensure that the refresh was successful. The authentication
-        information provided by OpenID Connect is decoded and validated, and
-        simple queries are performed to ensure that access is granted to all
-        USCDI data elements.
+        the GET HTTP method for code exchange.
+
+        After launch, a simple Patient resource read is performed on the patient
+        in context. The access token is then refreshed, and the Patient resource
+        is read using the new access token to ensure that the refresh was
+        successful. The authentication information provided by OpenID Connect is
+        decoded and validated, and simple queries are performed to ensure that
+        access is granted to all USCDI data elements.
+
+        Prior to running the scenario, register Inferno as a confidential client
+        with the following information:
+
+        * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
+
+        The following implementation specifications are relevant to this scenario:
 
         * [SMART on FHIR
           (STU1)](http://www.hl7.org/fhir/smart-app-launch/1.0.0/)

--- a/lib/onc_certification_g10_test_kit/smart_v1_scopes_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_v1_scopes_group.rb
@@ -24,7 +24,7 @@ module ONCCertificationG10TestKit
     )
 
     description %(
-        This scenario demonstrates the ability of a system to perform a
+        This scenario verifies the ability of a system to perform a
         Standalone Launch with v1 scopes, and then performs simple queries te
         ensure that access is granted to all resources.
 

--- a/lib/onc_certification_g10_test_kit/smart_v1_scopes_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_v1_scopes_group.rb
@@ -24,22 +24,32 @@ module ONCCertificationG10TestKit
     )
 
     description %(
-        This scenario verifies the ability of a system to perform a
-        Standalone Launch with v1 scopes, and then performs simple queries te
-        ensure that access is granted to all resources.
+        This scenario verifies the ability of a system to support a
+        Standalone Launch when v1 scopes are requested by the client.
+        It verifies that systems implement the `permission-v1` capability as required.
+        Previous scenarios focus on the use of the `permission-v2` capability,
+        and thus a dedicated launch is required to verify that systems
+        can support a client that requests `permission-v1` style scopes.
 
-        > For backwards compatibility with scopes defined in the SMART App
-          Launch 1.0 specification, servers SHOULD advertise the permission-v1
-          capability in their .well-known/smart-configuration discovery
-          document, SHOULD return v1 scopes when v1 scopes are requested and
-          granted, and SHOULD process v1 scopes with the following semantics in
-          v2:
+        This scenario does not place any constraints on the form of scopes
+        granted.  Systems are free to grant v1-style scopes in response to the
+        request for v1-style scopes, as recommended in the [SMART App Launch Guide STU2](http://hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html#scopes-for-requesting-fhir-resources).
+        Or they can upgrade them to v2-style scopes.  The scenario only ensures
+        that systems can grant access to clients that request v1-style scopes
+        and that the client has access to resources as expected.
 
-        > * v1 .read ⇒ v2 .rs
+        All relevant resource types must be granted, in a similar manner to the
+        'Standalone Patient App' scenario.
 
-        [SMART on FHIR Scopes for requesting FHIR Resources
-          (STU2)](http://hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html#scopes-for-requesting-fhir-resources)
+        This scenario expects Inferno to be registered as a 'Confidential
+        Symmetric' client.  Systems may either reuse a `client_id` associated
+        with Inferno used in a previous scenario, or register Inferno with a new
+        `client_id` as a standalone client with the following information:
+
+        * Redirect URI: `#{SMARTAppLaunch::AppRedirectTest.config.options[:redirect_uri]}`
+
       )
+
     id :g10_smart_v1_scopes
     run_as_group
 

--- a/lib/onc_certification_g10_test_kit/token_introspection_group.rb
+++ b/lib/onc_certification_g10_test_kit/token_introspection_group.rb
@@ -10,7 +10,7 @@ module ONCCertificationG10TestKit
 
     description <<~DESCRIPTION
 
-      This scenario demonstratates the ability of an authorization server to
+      This scenario verifies the ability of an authorization server to
       perform token introspection in accordance with the [SMART App Launch STU2
       Implementation Guide Section on Token
       Introspection](https://hl7.org/fhir/smart-app-launch/STU2/token-introspection.html).

--- a/lib/onc_certification_g10_test_kit/token_introspection_group.rb
+++ b/lib/onc_certification_g10_test_kit/token_introspection_group.rb
@@ -9,46 +9,33 @@ module ONCCertificationG10TestKit
     id :g10_token_introspection
 
     description <<~DESCRIPTION
-      # Background
 
-      OAuth 2.0 Token introspection, as described in
-      [RFC-7662](https://datatracker.ietf.org/doc/html/rfc7662), allows an
-      authorized resource server to query an OAuth 2.0 authorization server for
-      metadata on a token. The [SMART App Launch STU2 Implementation Guide
-      Section on Token
-      Introspection](https://hl7.org/fhir/smart-app-launch/STU2/token-introspection.html)
-      states that
-      > SMART on FHIR EHRs SHOULD support token introspection, which allows a
-      > broader ecosystem of resource servers to leverage authorization
-      > decisions managed by a single authorization server.
+      This scenario demonstratates the ability of an authorization server to
+      perform token introspection in accordance with the [SMART App Launch STU2
+      Implementation Guide Section on Token
+      Introspection](https://hl7.org/fhir/smart-app-launch/STU2/token-introspection.html).
+      Inferno first acts as a registered SMART App Launch client to request and
+      receive a valid access token, and then as an authorized resource server that
+      queries the authorization server for information about this access token.
 
-      # Test Methodology
+      The system under test must perform the following in order to pass this
+      scenario:
+      * Issue a new bearer token to Inferno acting as a registered SMART App
+        Launch client.  The tester has flexibility in deciding what type of SMART
+        App Launch client is used (e.g. public or confidential).  This is
+        redundant to tests earlier in this test suite, but is performed to ensure
+        an active token can be introspected.
+      * Respond to a token introspection request from Inferno acting as a
+        resource server for both valid and invalid tokens.  Systems have flexibility
+        in how access control for this service is implemented.  To account for
+        this flexibility, the tester has the ability to add an Authorization
+        Header to the request (provided out-of-band of these tests), as well as
+        additional Introspect parameters, as allowed by the specification.
 
-      In these tests, Inferno acts as an authorized resource server that queries
-      the authorization server about an access token, rather than a client to a
-      FHIR resource server as in the previous SMART App Launch tests. Ideally,
-      Inferno should be registered with the authorization server as an
-      authorized resource server capable of accessing the token introspection
-      endpoint through client credentials, per the SMART IG recommendations.
-      However, the SMART IG only formally REQUIRES "some form of authorization"
-      to access the token introspection endpoint and does not specifiy any one
-      specific approach. As such, the token introspection tests are broken up
-      into three groups that each complete a discrete step in the token
-      introspection process:
-
-      1. **Request Access Token Group** - repeats a subset of Standalone Launch
-        tests in order to receive a new access token with an authorization code
-        grant.
-      2. **Issue Token Introspection Request Group** - completes the
-        introspection requests.
-      3. **Validate Token Introspection Response Group** - validates the
-        contents of the introspection responses.
-
-      See the individual test groups for more details and guidance.
     DESCRIPTION
 
     input_instructions <<~INSTRUCTIONS
-      If the introspection endpoint is protected, testers must enter their own
+      If the introspection endpoint is access controlled, testers must enter their own
       HTTP Authorization header for the introspection request. See [RFC 7616 The
       'Basic' HTTP Authentication
       Scheme](https://datatracker.ietf.org/doc/html/rfc7617) for the most common

--- a/lib/onc_certification_g10_test_kit/token_revocation_group.rb
+++ b/lib/onc_certification_g10_test_kit/token_revocation_group.rb
@@ -2,7 +2,7 @@ module ONCCertificationG10TestKit
   class TokenRevocationGroup < Inferno::TestGroup
     title 'Token Revocation'
     description %(
-      Demonstrate the Health IT module is capable of revoking access granted to
+      This scenario verifies the ability of the system to revoke access granted to
       an application at the direction of a patient.  Access to the application
       must be revoked within one hour of the patient's request.
     )


### PR DESCRIPTION
A pass at refining all test descriptions.  Besides updating the new tests, I attempted to clean up existing test descriptions to make them more consistent as well.  For example, being consistent about use of headers in descriptions.

I stuck to the high-level descriptions.  I did not dive into the second, third and fourth level descriptions here, as I don't think those are nearly as important.