### PR TITLE
FI-3038: Use token refresh stu2 test for token refresh with scopes in asymmetric launch group

### DIFF
--- a/lib/onc_certification_g10_test_kit/base_token_refresh_stu2_group.rb
+++ b/lib/onc_certification_g10_test_kit/base_token_refresh_stu2_group.rb
@@ -37,7 +37,7 @@ module ONCCertificationG10TestKit
          }
     test from: :smart_token_refresh_body,
          id: :g10_token_refresh_body_without_scopes
-    test from: :smart_token_refresh,
+    test from: :smart_token_refresh_stu2,
          title: 'Server successfully refreshes the access token when optional scope parameter provided',
          id: :g10_token_refresh_with_scopes,
          config: {


### PR DESCRIPTION
See #548 for details of this issue.

To see the resolution, run group `9.12` with US Core 6 and SMART v2. [On prod](https://inferno.healthit.gov/suites/g10_certification/lwSEPAVZtns#g10_certification-Group06-g10_asymmetric_launch), the token refresh request in test `9.12.3.03` does not contain a `client_assertion`, so it is not using asymmetric auth. On this branch, that request will include a `client_assertion`, indicating that it is using asymmetric auth.

![Screenshot 2024-08-21 at 8 21 18 AM](https://github.com/user-attachments/assets/71e1b339-fb52-4caa-9765-e781829ac57d)
