### PR TITLE
FI-3018: Allow multi-line custom headers in token introspection request

### DIFF
--- a/lib/onc_certification_g10_test_kit/token_introspection_group.rb
+++ b/lib/onc_certification_g10_test_kit/token_introspection_group.rb
@@ -61,7 +61,7 @@ module ONCCertificationG10TestKit
 
     input_order :url,
                 :well_known_introspection_url,
-                :custom_authorization_header,
+                :custom_token_introspection_request_headers,
                 :optional_introspection_request_params,
                 :standalone_client_id,
                 :standalone_client_secret,


### PR DESCRIPTION
Update name of `custom_authorization_header` to `custom_token_introspection_request_headers` to account for change in SMART app launch test kit here: https://github.com/inferno-framework/smart-app-launch-test-kit/pull/77