### PR TITLE
FI-3027: Granular Scopes Test Failure to Skip

### DIFF
--- a/lib/onc_certification_g10_test_kit/smart_granular_scope_selection_test.rb
+++ b/lib/onc_certification_g10_test_kit/smart_granular_scope_selection_test.rb
@@ -33,7 +33,7 @@ module ONCCertificationG10TestKit
                "No resource-level scope was requested for #{resource_type}"
 
         granular_scope = requested_scopes.find { |scope| scope.match(granular_scope_regex(resource_type)) }
-        assert granular_scope.nil?, "Granular scope was requested: #{granular_scope}"
+        skip_if granular_scope.present?, "Granular scope was requested: #{granular_scope}"
       end
 
       assert received_scopes.present?

--- a/spec/onc_certification_g10_test_kit/smart_granular_scope_selection_test_spec.rb
+++ b/spec/onc_certification_g10_test_kit/smart_granular_scope_selection_test_spec.rb
@@ -44,13 +44,13 @@ RSpec.describe ONCCertificationG10TestKit::SMARTGranularScopeSelectionTest do
     expect(result.result_message).to match(/No resource-level scope was requested/)
   end
 
-  it 'fails if a granular scope is requested' do
+  it 'skips if a granular scope is requested' do
     scopes_with_granular = "#{requested_scopes} patient/Observation.rs?category=" \
                            'http://terminology.hl7.org/CodeSystem/observation-category|survey'
 
     result = run(test, requested_scopes: scopes_with_granular, received_scopes:)
 
-    expect(result.result).to eq('fail')
+    expect(result.result).to eq('skip')
     expect(result.result_message).to match(/Granular scope was requested/)
   end
 


### PR DESCRIPTION
The Granular Scopes 9.15.2.09 failure indicates the absence of a prerequisite needed to verify the behavior, so it should be a skip rather than a failure. This PR changes this Granular Scopes test so that the test skips rather than fails if granular scope is requested.