### PR TITLE
FI-3026: Fix Granular Scopes Group Token Exchange Requested Scopes Warning

### DIFF
--- a/lib/onc_certification_g10_test_kit/smart_granular_scope_selection_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_granular_scope_selection_group.rb
@@ -126,7 +126,8 @@ module ONCCertificationG10TestKit
               Tests will resume once Inferno receives a request at
               `#{config.options[:redirect_uri]}` with a state of `#{state}`.
             )
-          end
+          end,
+          ignore_missing_scopes_check: true
         }
       )
 


### PR DESCRIPTION
# Summary
To pass the SMART Granular Scope Selection group, it is necessary not to grant all requested scopes, but the test titled: 'Token exchange response body contains required information encoded in JSON' was warning users that not all requested scopes were granted. 

This PR updates the SMART Granular Scope Selection group so that it adds the `ignore_missing_scopes_check` option to the imported `smart_standalone_launch_stu2` test group so that the warning is not displayed.

# Testing Guidance
Run the SMART Granular Scope Selection group, and ensure that not granting all the requested scopes no longer adds a warning to the test titled: 'Token exchange response body contains required information encoded in JSON'.