### PR TITLE
FI-3367 Allow TLS tests to be disabled from env.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'tls_test_kit', git: 'https://github.com/inferno-framework/tls-test-kit.git', branch: 'FI-3367-disable-TLS-from-env'
+gem 'tls_test_kit', git: 'https://github.com/inferno-framework/tls-test-kit.git', branch: 'main'
 
 group :development, :test do
   gem 'rubocop', '~> 1.9'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'inferno_core', git: 'https://github.com/inferno-framework/inferno-core.git', branch: 'main'
 gem 'tls_test_kit', git: 'https://github.com/inferno-framework/tls-test-kit.git', branch: 'main'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'tls_test_kit', git: 'https://github.com/inferno-framework/tls-test-kit.git', branch: 'FI-3367-disable-TLS-from-env'
+
 group :development, :test do
   gem 'rubocop', '~> 1.9'
   gem 'rubocop-rspec', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/inferno-framework/tls-test-kit.git
+  revision: 7994aa5ba8d98d8ec726b2cca42242e6c9110dc3
+  branch: FI-3367-disable-TLS-from-env
+  specs:
+    tls_test_kit (0.2.2)
+      inferno_core (>= 0.4.2)
+
 PATH
   remote: .
   specs:
@@ -309,8 +317,6 @@ GEM
     strings-ansi (0.2.0)
     thor (1.2.2)
     tilt (2.4.0)
-    tls_test_kit (0.2.2)
-      inferno_core (>= 0.4.2)
     tty-color (0.6.0)
     tty-markdown (0.7.2)
       kramdown (>= 1.16.2, < 3.0)
@@ -349,6 +355,7 @@ DEPENDENCIES
   rubocop (~> 1.9)
   rubocop-rspec
   rubyXL
+  tls_test_kit!
   webmock (~> 3.11)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,40 @@
 GIT
+  remote: https://github.com/inferno-framework/inferno-core.git
+  revision: 39042af4ffe01bc3a6816348dfecfbff2245f52a
+  branch: main
+  specs:
+    inferno_core (0.4.43)
+      activesupport (~> 6.1.7.5)
+      base62-rb (= 0.3.1)
+      blueprinter (= 0.25.2)
+      dotenv (~> 2.7)
+      dry-configurable (= 1.0.0)
+      dry-container (= 0.10.0)
+      dry-core (= 1.0.0)
+      dry-inflector (= 1.0.0)
+      dry-system (= 1.0.0)
+      faraday (~> 1.2)
+      faraday_middleware (~> 1.2)
+      fhir_client (>= 5.0.3)
+      fhir_models (>= 4.2.2)
+      hanami-controller (= 2.0.0)
+      hanami-router (= 2.0.0)
+      oj (= 3.11.0)
+      pastel (~> 0.8.0)
+      pry
+      pry-byebug
+      puma (~> 5.6.7)
+      rake (~> 13.0)
+      sequel (~> 5.42.0)
+      sidekiq (~> 7.2.4)
+      sqlite3 (~> 1.4)
+      thor (~> 1.2.1)
+      tty-markdown (~> 0.7.1)
+
+GIT
   remote: https://github.com/inferno-framework/tls-test-kit.git
-  revision: 7994aa5ba8d98d8ec726b2cca42242e6c9110dc3
-  branch: FI-3367-disable-TLS-from-env
+  revision: 456ef01eddbcb0da0bb28c0d85e78877406c2f0c
+  branch: main
   specs:
     tls_test_kit (0.2.2)
       inferno_core (>= 0.4.2)
@@ -157,32 +190,6 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    inferno_core (0.4.43)
-      activesupport (~> 6.1.7.5)
-      base62-rb (= 0.3.1)
-      blueprinter (= 0.25.2)
-      dotenv (~> 2.7)
-      dry-configurable (= 1.0.0)
-      dry-container (= 0.10.0)
-      dry-core (= 1.0.0)
-      dry-inflector (= 1.0.0)
-      dry-system (= 1.0.0)
-      faraday (~> 1.2)
-      faraday_middleware (~> 1.2)
-      fhir_client (>= 5.0.3)
-      fhir_models (>= 4.2.2)
-      hanami-controller (= 2.0.0)
-      hanami-router (= 2.0.0)
-      oj (= 3.11.0)
-      pry
-      pry-byebug
-      puma (~> 5.6.7)
-      rake (~> 13.0)
-      sequel (~> 5.42.0)
-      sidekiq (~> 7.2.4)
-      sqlite3 (~> 1.4)
-      thor (~> 1.2.1)
-      tty-markdown (~> 0.7.1)
     io-console (0.5.11)
     irb (1.5.1)
       reline (>= 0.3.0)
@@ -350,6 +357,7 @@ DEPENDENCIES
   database_cleaner-sequel (~> 1.8)
   debug
   factory_bot (~> 6.1)
+  inferno_core!
   onc_certification_g10_test_kit!
   rspec (~> 3.10)
   rubocop (~> 1.9)


### PR DESCRIPTION
This is blocked by inferno-framework/tls-test-kit#20 and pending on CI for inferno-framework/inferno-reference-server#182.