### PR TITLE
FI-3391 Fix Could not find Observation.value[x]:valueQuantity in Bulk Data Testing

### DIFF
--- a/lib/onc_certification_g10_test_kit/g10_options.rb
+++ b/lib/onc_certification_g10_test_kit/g10_options.rb
@@ -56,6 +56,10 @@ module ONCCertificationG10TestKit
       us_core_version == US_CORE_7
     end
 
+    def us_core_7_and_above?
+      us_core_version[-1].to_i > 6
+    end
+
     def versioned_us_core_module
       case us_core_version
       when US_CORE_7

--- a/lib/onc_certification_g10_test_kit/profile_selector.rb
+++ b/lib/onc_certification_g10_test_kit/profile_selector.rb
@@ -60,6 +60,14 @@ module ONCCertificationG10TestKit
       when 'Observation'
         profiles << extract_profile('Smokingstatus') if observation_contains_code?(resource, '72166-2')
 
+        if us_core_7_and_above? && (
+              observation_contains_code?(resource, '11367-0') ||
+              observation_contains_code?(resource, '401201003') ||
+              observation_contains_code?(resource, '782516008')
+            )
+          profiles << extract_profile('Smokingstatus')
+        end
+
         profiles << extract_profile('ObservationLab') if resource_contains_category?(resource, 'laboratory', 'http://terminology.hl7.org/CodeSystem/observation-category')
 
         profiles << extract_profile('PediatricBmiForAge') if observation_contains_code?(resource, '59576-9')


### PR DESCRIPTION
# Summary:
This ticket fixed FI-3391 Reference Bulk Data server should return valid SmokingStatus Observation resource with valueQuantity

# Change Log:
* Update logic in profile_selector to handle additional US Core Smoking codes specified in US Core 7

# Testing:
Start (g)(10) test kit with US Core v7 and Bulk Data v2
Run Test Group 8 Multi-Patient API STU2

All tests shall pass