### PR TITLE
FI-3023: Bump validator to 1.0.59

### DIFF
--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -29,7 +29,7 @@ services:
       - ./data/redis:/data
     command: redis-server --appendonly yes
   hl7_validator_service:
-    image: infernocommunity/inferno-resource-validator:1.0.58
+    image: infernocommunity/inferno-resource-validator:1.0.59
     environment:
       # Defines how long validator sessions last if unused, in minutes:
       # Negative values mean sessions never expire, 0 means sessions immediately expire

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -4,7 +4,7 @@ module ONCCertificationG10TestKit
   class ConfigurationChecker
     EXPECTED_VALIDATOR_VERSION = '2.3.2'.freeze
     INFERNO_VALIDATOR_VERSION_KEY = 'inferno-framework/fhir-validator-wrapper'.freeze
-    EXPECTED_HL7_VALIDATOR_VERSION = '1.0.58'.freeze
+    EXPECTED_HL7_VALIDATOR_VERSION = '1.0.59'.freeze
     HL7_VALIDATOR_VERSION_KEY = 'validatorWrapperVersion'.freeze
 
     def configuration_messages


### PR DESCRIPTION
Bump the validator to version 1.0.59 which is the most recent as of today. Their version endpoint has changed to return a JSON, just like our validator did, so I updated the configuration checker logic to handle that. Sample version response from https://validator.fhir.org/validator/version :
```
{
  "validatorWrapperVersion": "1.0.59-SNAPSHOT",
  "validatorVersion": "6.4.4"
}
```


Note that I also changed the expected version to be the wrapper version (1.0.59) not the core validator version (6.4.4) since that's the version actually specified in docker-compose, and I hope that will be less confusing.


Fortunately this release compared to 1.0.52 doesn't seem to have resulted in any new error messages for our reference server data, so nothing new to add to message filters.