### PR TITLE
FI-3428: Prevent systems from passing with US core 7 and SMART App Launch 1

### DIFF
--- a/lib/onc_certification_g10_test_kit/short_id_map.yml
+++ b/lib/onc_certification_g10_test_kit/short_id_map.yml
@@ -6,6 +6,7 @@ g10_certification-g10_smart_standalone_patient_app-smart_discovery-Test02: 1.1.0
 g10_certification-g10_smart_standalone_patient_app-smart_discovery-Test03: 1.1.03
 g10_certification-g10_smart_standalone_patient_app-smart_discovery-Test04: 1.1.04
 g10_certification-g10_smart_standalone_patient_app-smart_discovery-g10_smart_well_known_capabilities: 1.1.05
+g10_certification-g10_smart_standalone_patient_app-smart_discovery-g10_us_core_7_smart_version_check: 1.1.06
 g10_certification-g10_smart_standalone_patient_app-smart_discovery_stu2: '1.2'
 g10_certification-g10_smart_standalone_patient_app-smart_discovery_stu2-well_known_endpoint: 1.2.01
 g10_certification-g10_smart_standalone_patient_app-smart_discovery_stu2-well_known_capabilities_stu2: 1.2.02

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -96,6 +96,12 @@ module ONCCertificationG10TestKit
 
         id :g10_us_core_7_smart_version_check
         title 'US Core 7 requires SMART App Launch STU2+'
+        description %(
+          The [US Core 7 SMART on FHIR Obligations and
+          Capabilities](https://hl7.org/fhir/us/core/scopes.html) require SMART
+          App Launch STU2+, so systems can not certify with US Core 7 and SMART
+          App Launch STU1.
+        )
 
         run do
           assert false, 'US Core 7 is not eligible for certification with SMART App Launch STU1.'

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -112,7 +112,8 @@ module ONCCertificationG10TestKit
         )
 
         run do
-          assert false, 'US Core 7 is not eligible for certification with SMART App Launch STU1.'
+          assert false, 'US Core 7 is not eligible for certification with SMART App Launch 1.0.0. ' \
+                        'Start a new session with SMART App Launch 2.0.0 or higher.'
         end
       end
     end

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -95,12 +95,12 @@ module ONCCertificationG10TestKit
         required_suite_options(G10Options::US_CORE_7_REQUIREMENT)
 
         id :g10_us_core_7_smart_version_check
-        title 'US Core 7 requires SMART App Launch STU2+'
+        title 'US Core 7 requires SMART App Launch 2.0.0 or above'
         description %(
           The [US Core 7 SMART on FHIR Obligations and
           Capabilities](https://hl7.org/fhir/us/core/scopes.html) require SMART
-          App Launch STU2+, so systems can not certify with US Core 7 and SMART
-          App Launch STU1.
+          App Launch 2.0.0 or above, so systems can not certify with US Core 7
+          and SMART App Launch 1.0.0.
 
           The [Test
           Procedure](https://www.healthit.gov/test-method/standardized-api-patient-and-population-services)

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -90,6 +90,17 @@ module ONCCertificationG10TestKit
                ]
              }
            }
+
+      test do
+        required_suite_options(G10Options::US_CORE_7_REQUIREMENT)
+
+        id :g10_us_core_7_smart_version_check
+        title 'US Core 7 requires SMART App Launch STU2+'
+
+        run do
+          assert false, 'US Core 7 is not eligible for certification with SMART App Launch STU1.'
+        end
+      end
     end
 
     group from: :smart_discovery_stu2 do

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -98,9 +98,9 @@ module ONCCertificationG10TestKit
         title 'US Core 7 requires SMART App Launch 2.0.0 or above'
         description %(
           The [US Core 7 SMART on FHIR Obligations and
-          Capabilities](https://hl7.org/fhir/us/core/scopes.html) require SMART
-          App Launch 2.0.0 or above, so systems can not certify with US Core 7
-          and SMART App Launch 1.0.0.
+          Capabilities](https://hl7.org/fhir/us/core/STU7/scopes.html) require
+          SMART App Launch 2.0.0 or above, so systems can not certify with US
+          Core 7 and SMART App Launch 1.0.0.
 
           The [Test
           Procedure](https://www.healthit.gov/test-method/standardized-api-patient-and-population-services)

--- a/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_standalone_patient_app_group.rb
@@ -101,6 +101,14 @@ module ONCCertificationG10TestKit
           Capabilities](https://hl7.org/fhir/us/core/scopes.html) require SMART
           App Launch STU2+, so systems can not certify with US Core 7 and SMART
           App Launch STU1.
+
+          The [Test
+          Procedure](https://www.healthit.gov/test-method/standardized-api-patient-and-population-services)
+          also states in **Paragraph (g)(10)(v)(A) – Authentication and
+          authorization for patient and user scopes**:
+
+          > Note: US Core 7.0.0 must be tested with SMART App Launch 2.0.0 or
+            above.
         )
 
         run do


### PR DESCRIPTION
This branch adds a failing test to the discovery group in the standalone patient app group when US Core 7 and SMART App Launch 1 are selected.

![Screenshot 2024-12-18 at 9 39 14 AM](https://github.com/user-attachments/assets/6e6aa595-9df3-452f-9f6f-ad71f4614ddf)

