### PR TITLE
FI-3565: Bump validator to 1.0.60

### DIFF
--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -29,7 +29,7 @@ services:
       - ./data/redis:/data
     command: redis-server --appendonly yes
   hl7_validator_service:
-    image: infernocommunity/inferno-resource-validator:1.0.59
+    image: infernocommunity/inferno-resource-validator:1.0.60
     environment:
       # Defines how long validator sessions last if unused, in minutes:
       # Negative values mean sessions never expire, 0 means sessions immediately expire

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -4,7 +4,7 @@ module ONCCertificationG10TestKit
   class ConfigurationChecker
     EXPECTED_VALIDATOR_VERSION = '2.3.2'.freeze
     INFERNO_VALIDATOR_VERSION_KEY = 'inferno-framework/fhir-validator-wrapper'.freeze
-    EXPECTED_HL7_VALIDATOR_VERSION = '1.0.59'.freeze
+    EXPECTED_HL7_VALIDATOR_VERSION = '1.0.60'.freeze
     HL7_VALIDATOR_VERSION_KEY = 'validatorWrapperVersion'.freeze
 
     def configuration_messages


### PR DESCRIPTION
Bump the validator to version 1.0.60 which is the most recent as of today. 
This release has no breaking changes to the validation service API or configuration options, and does not introduce any new error messages for our reference server data based on testing against all 4 g10 x US Core version options.