### PR TITLE
FI-3642 Updates wiki workflow to allow manual synchronization for previewing.

### DIFF
--- a/.github/workflows/publish-docs-wiki.yml
+++ b/.github/workflows/publish-docs-wiki.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - docs/**
   workflow_dispatch:
-  pull_request:
-    types: [closed]
-    paths:
-      - docs/**
 concurrency:
   group: publish-docs-wiki
   cancel-in-progress: true

--- a/.github/workflows/publish-docs-wiki.yml
+++ b/.github/workflows/publish-docs-wiki.yml
@@ -1,20 +1,24 @@
-name: Publish wiki
+name: Publish Docs Wiki
 on:
   push:
     branches: [main]
     paths:
       - docs/**
-      - .github/workflows/publish-wiki.yml
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+    paths:
+      - docs/**
 concurrency:
-  group: publish-wiki
+  group: publish-docs-wiki
   cancel-in-progress: true
 permissions:
   contents: write
 jobs:
-  publish-wiki:
+  publish-docs-wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Andrew-Chen-Wang/github-wiki-action@86138cbd6328b21d759e89ab6e6dd6a139b22270
         with:
           path: docs


### PR DESCRIPTION
Allows users to 'preview' docs changes to the wiki, as in practice it is hard to ensure that docs changes look and work properly within the wiki which ends up creating a lot of junk PRs.  Enables the workflow to be run manually via the Actions against any branch.  ~Also automatically resynchs wiki docs to `main` on closure for any PR that has docs changes, just in case it was manually synchronized but not undone.~ (removed that run-on-close feature because it is spammy on merges, which counts as a PR closure)

Originally I created a workflow that would synchronize to the wiki automatically if a title contained something like '(DOCS)' in it.

But this requires people to know that this functionality exists.  And at that point, it just seems simpler to allow manual execution of this via the workflow tab.  So, the user opens a PR, goes to the Actions area, runs this against the new branch, which synchronizes the wiki.  Takes a look.  And then can resynchronize it back to main if they want, or let the reviewer take a look.

Less code, less magic stuff happening automatically.

I confirmed it work over here so I think this is a low risk merge with limited review: https://github.com/arscan/docs-test-kit/pull/7.