### PR TITLE
concurrent-ruby 1.3.5 causes failures Inferno runs, pinning to version 1.3.4

### DIFF
--- a/onc_certification_g10_test_kit.gemspec
+++ b/onc_certification_g10_test_kit.gemspec
@@ -25,6 +25,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'tls_test_kit', '0.2.3'
   spec.add_runtime_dependency 'us_core_test_kit', '0.9.3'
 
+  # concurrent-ruby 1.3.5 causes failures Inferno runs, pin to 1.3.4
+  spec.add_runtime_dependency 'concurrent-ruby', '= 1.3.4'
+
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'
   spec.add_development_dependency 'rspec', '~> 3.10'


### PR DESCRIPTION
When installing the new ruby bundler and re-installing the gems defined in `onc_certification_g10_test_kit.gemspec` the project pulls in a couple new dependencies. I found that the upgrade of `concurrent-ruby` from 1.3.4 -> 1.3.5 breaks the `inferno` docker compose service run with the following error below. 

To resolve this for the time being `concurrent-ruby` should be pinned at 1.3.4 to ensure others do not experience these deployment issues.

Steps I took to update ruby bundler and re-install gems and recreate errors by installing `concurrent-ruby` 1.3.5 version.

`gem install bundler`
`rm Gemfile.lock`
`bundle install`

```bash
bundler: failed to load command: inferno (/usr/local/bundle/bin/inferno)
/usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:16:in `<module:LoggerThreadSafeLevel>': uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)

    Logger::Severity.constants.each do |severity|
    ^^^^^^
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:8:in `<top (required)>'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_silence.rb:5:in `require'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_silence.rb:5:in `<top (required)>'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger.rb:3:in `require'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger.rb:3:in `<top (required)>'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support.rb:29:in `require'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support.rb:29:in `<top (required)>'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/all.rb:3:in `require'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/all.rb:3:in `<top (required)>'
	from /usr/local/bundle/gems/inferno_core-0.5.4/lib/inferno/config/application.rb:1:in `require'
	from /usr/local/bundle/gems/inferno_core-0.5.4/lib/inferno/config/application.rb:1:in `<top (required)>'
	from /usr/local/bundle/gems/inferno_core-0.5.4/bin/inferno:4:in `require_relative'
	from /usr/local/bundle/gems/inferno_core-0.5.4/bin/inferno:4:in `<top (required)>'
	from /usr/local/bundle/bin/inferno:25:in `load'
	from /usr/local/bundle/bin/inferno:25:in `<top (required)>'
	from /usr/local/bundle/gems/bundler-2.6.3/lib/bundler/cli/exec.rb:59:in `load'
	from /usr/local/bundle/gems/bundler-2.6.3/lib/bundler/cli/exec.rb:59:in `kernel_load'
	from /usr/local/bundle/gems/bundler-2.6.3/lib/bundler/cli/exec.rb:23:in `run'
	from /usr/local/bundle/gems/bundler-2.6.3/lib/bundler/cli.rb:452:in `exec'
	from /usr/local/bundle/gems/bundler-2.6.3/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
	from /usr/local/bundle/gems/bundler-2.6.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /usr/local/bundle/gems/bundler-2.6.3/lib/bundler/vendor/thor/lib/thor.rb:538:in `dispatch'
	from /usr/local/bundle/gems/bundler-2.6.3/lib/bundler/cli.rb:35:in `dispatch'
	from /usr/local/bundle/gems/bundler-2.6.3/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
	from /usr/local/bundle/gems/bundler-2.6.3/lib/bundler/cli.rb:29:in `start'
	from /usr/local/bundle/gems/bundler-2.6.3/exe/bundle:28:in `block in <top (required)>'
	from /usr/local/bundle/gems/bundler-2.6.3/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
	from /usr/local/bundle/gems/bundler-2.6.3/exe/bundle:20:in `<top (required)>'
	from /usr/local/bundle/bin/bundle:25:in `load'
	from /usr/local/bundle/bin/bundle:25:in `<main>'
```
