### PR TITLE
FI-3728: Fix importing to not alter the imported groups

### DIFF
--- a/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_api_group.rb
@@ -111,23 +111,24 @@ module ONCCertificationG10TestKit
       end
     end
 
-    USCoreTestKit::USCoreV311::USCoreTestSuite.groups[1].groups.each do |group|
-      test_group = group.ancestors[1]
+    USCoreTestKit::USCoreV311::USCoreTestSuite
+      .groups
+      .find { |g| g.title == 'US Core FHIR API' }
+      .groups
+      .each do |group|
+        test_group = group.ancestors[1]
 
-      next if test_group.optional?
+        next if test_group.optional?
 
-      id = test_group.id
+        group(from: test_group.id, exclude_optional: true)
 
-      group_config = {}
-      if test_group.respond_to?(:metadata) &&
-         test_group.metadata.delayed? &&
-         !test_group.metadata.searchable_delayed_resource?
-        test_group.children.reject! { |child| child.include? USCoreTestKit::SearchTest }
-        group_config[:options] = { read_all_resources: true }
+        if test_group.respond_to?(:metadata) && # rubocop:disable Style/Next
+           test_group.metadata.delayed? &&
+           !test_group.metadata.searchable_delayed_resource?
+          groups.last.children.reject! { |child| child.include? USCoreTestKit::SearchTest }
+          groups.last.config(options: { read_all_resources: true })
+        end
       end
-
-      group(from: id, exclude_optional: true, config: group_config)
-    end
 
     groups.first.description %(
       The Capability Statement test verifies a FHIR server's ability support the

--- a/lib/onc_certification_g10_test_kit/single_patient_us_core_4_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_us_core_4_api_group.rb
@@ -123,23 +123,24 @@ module ONCCertificationG10TestKit
       end
     end
 
-    USCoreTestKit::USCoreV400::USCoreTestSuite.groups[1].groups.each do |group|
-      test_group = group.ancestors[1]
+    USCoreTestKit::USCoreV400::USCoreTestSuite
+      .groups
+      .find { |g| g.title == 'US Core FHIR API' }
+      .groups
+      .each do |group|
+        test_group = group.ancestors[1]
 
-      next if test_group.optional?
+        next if test_group.optional?
 
-      id = test_group.id
+        group(from: test_group.id, exclude_optional: true)
 
-      group_config = {}
-      if test_group.respond_to?(:metadata) &&
-         test_group.metadata.delayed? &&
-         !test_group.metadata.searchable_delayed_resource?
-        test_group.children.reject! { |child| child.include? USCoreTestKit::SearchTest }
-        group_config[:options] = { read_all_resources: true }
+        if test_group.respond_to?(:metadata) && # rubocop:disable Style/Next
+           test_group.metadata.delayed? &&
+           !test_group.metadata.searchable_delayed_resource?
+          groups.last.children.reject! { |child| child.include? USCoreTestKit::SearchTest }
+          groups.last.config(options: { read_all_resources: true })
+        end
       end
-
-      group(from: id, exclude_optional: true, config: group_config)
-    end
 
     groups.first.description %(
       The Capability Statement test verifies a FHIR server's ability support the

--- a/lib/onc_certification_g10_test_kit/single_patient_us_core_5_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_us_core_5_api_group.rb
@@ -137,23 +137,24 @@ module ONCCertificationG10TestKit
       end
     end
 
-    USCoreTestKit::USCoreV501::USCoreTestSuite.groups[1].groups.each do |group|
-      test_group = group.ancestors[1]
+    USCoreTestKit::USCoreV501::USCoreTestSuite
+      .groups
+      .find { |g| g.title == 'US Core FHIR API' }
+      .groups
+      .each do |group|
+        test_group = group.ancestors[1]
 
-      next if test_group.optional?
+        next if test_group.optional?
 
-      id = test_group.id
+        group(from: test_group.id, exclude_optional: true)
 
-      group_config = {}
-      if test_group.respond_to?(:metadata) &&
-         test_group.metadata.delayed? &&
-         !test_group.metadata.searchable_delayed_resource?
-        test_group.children.reject! { |child| child.include? USCoreTestKit::SearchTest }
-        group_config[:options] = { read_all_resources: true }
+        if test_group.respond_to?(:metadata) && # rubocop:disable Style/Next
+           test_group.metadata.delayed? &&
+           !test_group.metadata.searchable_delayed_resource?
+          groups.last.children.reject! { |child| child.include? USCoreTestKit::SearchTest }
+          groups.last.config(options: { read_all_resources: true })
+        end
       end
-
-      group(from: id, exclude_optional: true, config: group_config)
-    end
 
     groups.first.description %(
       The Capability Statement test verifies a FHIR server's ability support the

--- a/lib/onc_certification_g10_test_kit/single_patient_us_core_6_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_us_core_6_api_group.rb
@@ -166,26 +166,27 @@ module ONCCertificationG10TestKit
       end
     end
 
-    USCoreTestKit::USCoreV610::USCoreTestSuite.groups[1].groups.each do |group|
-      test_group = group.ancestors[1]
+    USCoreTestKit::USCoreV610::USCoreTestSuite
+      .groups
+      .find { |g| g.title == 'US Core FHIR API' }
+      .groups
+      .each do |group|
+        test_group = group.ancestors[1]
 
-      next if test_group.optional?
+        next if test_group.optional?
 
-      id = test_group.id
+        group(from: test_group.id, exclude_optional: true)
 
-      group_config = {}
-      if test_group.respond_to?(:metadata) &&
-         test_group.metadata.delayed? &&
-         !test_group.metadata.searchable_delayed_resource?
-        test_group.children.reject! do |child|
-          child.include?(USCoreTestKit::SearchTest) &&
-            !child.include?(USCoreTestKit::PractitionerAddressTest)
+        if test_group.respond_to?(:metadata) && # rubocop:disable Style/Next
+           test_group.metadata.delayed? &&
+           !test_group.metadata.searchable_delayed_resource?
+          groups.last.children.reject! do |child|
+            child.include?(USCoreTestKit::SearchTest) &&
+              !child.include?(USCoreTestKit::PractitionerAddressTest)
+          end
+          groups.last.config(options: { read_all_resources: true })
         end
-        group_config[:options] = { read_all_resources: true }
       end
-
-      group(from: id, exclude_optional: true, config: group_config)
-    end
 
     groups.first.description %(
       The Capability Statement test verifies a FHIR server's ability support the

--- a/lib/onc_certification_g10_test_kit/single_patient_us_core_7_api_group.rb
+++ b/lib/onc_certification_g10_test_kit/single_patient_us_core_7_api_group.rb
@@ -171,26 +171,27 @@ module ONCCertificationG10TestKit
       end
     end
 
-    USCoreTestKit::USCoreV700::USCoreTestSuite.groups.find { |g| g.title == 'US Core FHIR API' }.groups.each do |group|
-      test_group = group.ancestors[1]
+    USCoreTestKit::USCoreV700::USCoreTestSuite
+      .groups
+      .find { |g| g.title == 'US Core FHIR API' }
+      .groups
+      .each do |group|
+        test_group = group.ancestors[1]
 
-      next if test_group.optional?
+        next if test_group.optional?
 
-      id = test_group.id
+        group(from: test_group.id, exclude_optional: true)
 
-      group_config = {}
-      if test_group.respond_to?(:metadata) &&
-         test_group.metadata.delayed? &&
-         !test_group.metadata.searchable_delayed_resource?
-        test_group.children.reject! do |child|
-          child.include?(USCoreTestKit::SearchTest) &&
-            !child.include?(USCoreTestKit::PractitionerAddressTest)
+        if test_group.respond_to?(:metadata) && # rubocop:disable Style/Next
+           test_group.metadata.delayed? &&
+           !test_group.metadata.searchable_delayed_resource?
+          groups.last.children.reject! do |child|
+            child.include?(USCoreTestKit::SearchTest) &&
+              !child.include?(USCoreTestKit::PractitionerAddressTest)
+          end
+          groups.last.config(options: { read_all_resources: true })
         end
-        group_config[:options] = { read_all_resources: true }
       end
-
-      group(from: id, exclude_optional: true, config: group_config)
-    end
 
     groups.first.description %(
       The Capability Statement test verifies a FHIR server's ability support the


### PR DESCRIPTION
This branch alters how g10 imports tests from US Core so that it doesn't alter the original groups in US Core.

On main, run `bundle exec inferno c`. Then in the console, run `USCoreTestKit::USCoreV311::USCoreTestSuite.groups[1].groups[-5].ancestors[1].children`. You will see that it does not include any search tests because that group was altered during by the `reject!` call in the g10 import. If you do the same on this branch, you should see that the search tests are still there since now the imported group is being altered rather than the original source group.

The groups in g10 should contain the same tests as they do on main.