### PR TITLE
FI-3513: Remove legacy validator support

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,4 @@
 JS_HOST=""
-G10_VALIDATOR_URL=http://validator_service:4567
 FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
 REDIS_URL=redis://redis:6379/0
 

--- a/.env
+++ b/.env
@@ -3,13 +3,6 @@ G10_VALIDATOR_URL=http://validator_service:4567
 FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
 REDIS_URL=redis://redis:6379/0
 
-USE_HL7_RESOURCE_VALIDATOR=true
-# To use the HL7 validator wrapper instead of the inferno validator wrapper, set the above to true,
-# and uncomment the relevant settings in the following files:
-#  - docker-compose.yml -- "hl7_validator_service" section at the bottom
-#  - docker-compose.background.yml -- "hl7_validator_service" section at the bottom
-#  - nginx.background.conf -- "location /hl7validatorapi/" section at the bottom
-
 # Full path to a custom JWKS json file, will use lib/onc_certification_g10_test_kit/bulk_data_jwks.json if left blank
 # G10_BULK_DATA_JWKS=
 

--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,4 @@
 G10_VALIDATOR_URL=http://localhost/validatorapi
 FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
-VALIDATOR_URL=http://localhost/validatorapi
 REDIS_URL=redis://localhost:6379/0
 INFERNO_HOST=http://localhost:4567

--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,3 @@
 REDIS_URL=redis://redis:6379/0
-G10_VALIDATOR_URL=http://validator_service:4567
-VALIDATOR_URL=http://validator_service:4567
 FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500
 INFERNO_HOST=http://localhost

--- a/config/nginx.background.conf
+++ b/config/nginx.background.conf
@@ -53,39 +53,6 @@ http {
     # the server will close connections after this time
     keepalive_timeout 600;
 
-    # location /validator {
-    #   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    #   proxy_set_header Host $http_host;
-    #   proxy_set_header X-Forwarded-Proto $scheme;
-    #   proxy_set_header X-Forwarded-Port $server_port;
-    #   proxy_redirect off;
-    #   proxy_set_header Connection '';
-    #   proxy_http_version 1.1;
-    #   chunked_transfer_encoding off;
-    #   proxy_buffering off;
-    #   proxy_cache off;
-
-    #   proxy_pass http://fhir_validator_app;
-    # }
-
-    # location /validatorapi/ {
-    #   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    #   proxy_set_header Host $http_host;
-    #   proxy_set_header X-Forwarded-Proto $scheme;
-    #   proxy_set_header X-Forwarded-Port $server_port;
-    #   proxy_redirect off;
-    #   proxy_set_header Connection '';
-    #   proxy_http_version 1.1;
-    #   chunked_transfer_encoding off;
-    #   proxy_buffering off;
-    #   proxy_cache off;
-
-    #   proxy_pass http://validator_service:4567/;
-    # }
-
-
-# To enable the HL7 Validator Wrapper, both the section below and
-# the section in docker-compose.background.yml need to be uncommented
    location /hl7validatorapi/ {
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      proxy_set_header Host $http_host;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -67,35 +67,5 @@ http {
 
       proxy_pass http://inferno:4567;
     }
-
-    # location /validator {
-    #   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    #   proxy_set_header Host $http_host;
-    #   proxy_set_header X-Forwarded-Proto $scheme;
-    #   proxy_set_header X-Forwarded-Port $server_port;
-    #   proxy_redirect off;
-    #   proxy_set_header Connection '';
-    #   proxy_http_version 1.1;
-    #   chunked_transfer_encoding off;
-    #   proxy_buffering off;
-    #   proxy_cache off;
-
-    #   proxy_pass http://fhir_validator_app;
-    # }
-
-    # location /validatorapi/ {
-    #   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    #   proxy_set_header Host $http_host;
-    #   proxy_set_header X-Forwarded-Proto $scheme;
-    #   proxy_set_header X-Forwarded-Port $server_port;
-    #   proxy_redirect off;
-    #   proxy_set_header Connection '';
-    #   proxy_http_version 1.1;
-    #   chunked_transfer_encoding off;
-    #   proxy_buffering off;
-    #   proxy_cache off;
-
-    #   proxy_pass http://validator_service:4567/;
-    # }
   }
 }

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -1,19 +1,5 @@
 version: '3'
 services:
-  # validator_service:
-  #   image: infernocommunity/fhir-validator-service:v2.3.2
-  #   environment:
-  #     - DISABLE_TX= true
-  #     - DISPLAY_ISSUES_ARE_WARNINGS=true
-  #   volumes:
-  #     - ./lib/onc_certification_g10_test_kit/igs:/home/igs
-  # fhir_validator_app:
-  #   image: infernocommunity/fhir-validator-app
-  #   depends_on:
-  #     - validator_service
-  #   environment:
-  #     EXTERNAL_VALIDATOR_URL: http://localhost/validatorapi
-  #     VALIDATOR_BASE_PATH: /validator
   nginx:
     image: nginx
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - ./data:/opt/inferno/data
     depends_on:
       - hl7_validator_service
-      # - validator_service
   worker:
     build:
       context: ./
@@ -16,14 +15,6 @@ services:
     command: bundle exec sidekiq -r ./worker.rb
     depends_on:
       - redis
-  # validator_service:
-  #   extends:
-  #     file: docker-compose.background.yml
-  #     service: validator_service
-  # fhir_validator_app:
-  #   extends:
-  #     file: docker-compose.background.yml
-  #     service: fhir_validator_app
   nginx:
     extends:
       file: docker-compose.background.yml

--- a/lib/onc_certification_g10_test_kit.rb
+++ b/lib/onc_certification_g10_test_kit.rb
@@ -88,26 +88,16 @@ module ONCCertificationG10TestKit
     ].freeze
 
     def self.setup_validator(us_core_version_requirement) # rubocop:disable Metrics/CyclomaticComplexity
-      validator_method = if Feature.use_hl7_resource_validator?
-                           method(:fhir_resource_validator)
-                         else
-                           method(:validator)
-                         end
-
-      validator_method.call :default, required_suite_options: us_core_version_requirement do
-        if Feature.use_hl7_resource_validator?
-          cli_context do
-            txServer nil
-            displayWarnings true
-            disableDefaultResourceFetcher true
-          end
-
-          us_core_version_num = G10Options::US_CORE_VERSION_NUMBERS[us_core_version_requirement[:us_core_version]]
-
-          igs("hl7.fhir.us.core##{us_core_version_num}")
-        else
-          url ENV.fetch('G10_VALIDATOR_URL', 'http://validator_service:4567')
+      fhir_resource_validator :default, required_suite_options: us_core_version_requirement do
+        cli_context do
+          txServer nil
+          displayWarnings true
+          disableDefaultResourceFetcher true
         end
+
+        us_core_version_num = G10Options::US_CORE_VERSION_NUMBERS[us_core_version_requirement[:us_core_version]]
+
+        igs("hl7.fhir.us.core##{us_core_version_num}")
 
         us_core_message_filters =
           case (us_core_version_requirement[:us_core_version])

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -2,8 +2,6 @@ require_relative '../inferno/terminology/tasks/check_built_terminology'
 
 module ONCCertificationG10TestKit
   class ConfigurationChecker
-    EXPECTED_VALIDATOR_VERSION = '2.3.2'.freeze
-    INFERNO_VALIDATOR_VERSION_KEY = 'inferno-framework/fhir-validator-wrapper'.freeze
     EXPECTED_HL7_VALIDATOR_VERSION = '1.0.60'.freeze
     HL7_VALIDATOR_VERSION_KEY = 'validatorWrapperVersion'.freeze
 
@@ -24,15 +22,9 @@ module ONCCertificationG10TestKit
     end
 
     def validator_version_message
-      if Feature.use_hl7_resource_validator?
-        expected_validator_version = EXPECTED_HL7_VALIDATOR_VERSION
-        validator_version_key = HL7_VALIDATOR_VERSION_KEY
-        validator_version_url = "#{validator_url}/validator/version"
-      else
-        expected_validator_version = EXPECTED_VALIDATOR_VERSION
-        validator_version_key = INFERNO_VALIDATOR_VERSION_KEY
-        validator_version_url = "#{validator_url}/version"
-      end
+      expected_validator_version = EXPECTED_HL7_VALIDATOR_VERSION
+      validator_version_key = HL7_VALIDATOR_VERSION_KEY
+      validator_version_url = "#{validator_url}/validator/version"
 
       response = Faraday.get validator_version_url
       if response.body.starts_with? '{'

--- a/lib/onc_certification_g10_test_kit/feature.rb
+++ b/lib/onc_certification_g10_test_kit/feature.rb
@@ -1,9 +1,10 @@
 module ONCCertificationG10TestKit
   module Feature
-    class << self
-      def use_hl7_resource_validator?
-        ENV.fetch('USE_HL7_RESOURCE_VALIDATOR', 'false')&.casecmp?('true')
-      end
+    class << self # rubocop:disable Lint/EmptyClass
+      # This is how you can define feature flags to be used in the g10 test kit
+      # def us_core_v4?
+      #   ENV.fetch('US_CORE_4_ENABLED', 'false')&.casecmp?('true')
+      # end
     end
   end
 end

--- a/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_group_export_validation_spec.rb
@@ -185,14 +185,8 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataGroupExportValidation do
         .with(headers: { 'Accept' => 'application/fhir+ndjson' })
         .to_return(status: 200, body: contents, headers:)
 
-      # Ideally this would run twice, once with each validator setting
-      if ONCCertificationG10TestKit::Feature.use_hl7_resource_validator?
-        validation_stub_url = "#{validator_url}/validate"
-        validation_stub_body = validation_response_no_name
-      else
-        validation_stub_url = "#{validator_url}/validate?profile=http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-        validation_stub_body = operation_outcome_no_name.to_json
-      end
+      validation_stub_url = "#{validator_url}/validate"
+      validation_stub_body = validation_response_no_name
 
       validation_request = stub_request(:post, validation_stub_url)
         .to_return(status: 200, body: validation_stub_body)

--- a/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
@@ -1,10 +1,8 @@
 RSpec.describe 'Resource Validation' do # rubocop:disable RSpec/DescribeClass
   let(:resource) { FHIR.from_contents('{"resourceType": "Immunization", "id": "123"}') }
 
-  def reset_g10_validators(use_hl7_resource_validator)
+  def reset_g10_validators
     ONCCertificationG10TestKit::G10CertificationSuite.fhir_validators[:default].clear
-
-    ENV['USE_HL7_RESOURCE_VALIDATOR'] = use_hl7_resource_validator.to_s
 
     [
       ONCCertificationG10TestKit::G10Options::US_CORE_3_REQUIREMENT,
@@ -18,65 +16,9 @@ RSpec.describe 'Resource Validation' do # rubocop:disable RSpec/DescribeClass
     end
   end
 
-  describe 'with Inferno validator wrapper' do
-    before do
-      reset_g10_validators(false)
-    end
-
-    let(:runnable) { ONCCertificationG10TestKit::G10CertificationSuite.groups.first.groups.first.tests.first.new }
-    let(:validator_url) { runnable.find_validator(:default).url }
-    let(:operation_outcome_string1) do
-      File.read(File.join(__dir__, '..', 'fixtures', 'OperationOutcome-code-invalid-1.json'))
-    end
-    let(:operation_outcome_string2) do
-      File.read(File.join(__dir__, '..', 'fixtures', 'OperationOutcome-code-invalid-2.json'))
-    end
-
-    it 'excludes Unknown Code messages' do
-      stub_request(:post, "#{validator_url}/validate?profile=PROFILE")
-        .to_return(status: 200, body: operation_outcome_string1)
-
-      expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
-      expect(runnable.messages.length).to be_zero
-    end
-
-    it 'excludes CodeableConcept not in VS messages' do
-      stub_request(:post, "#{validator_url}/validate?profile=PROFILE")
-        .to_return(status: 200, body: operation_outcome_string2)
-
-      expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
-      expect(runnable.messages.length).to be_zero
-    end
-
-    it 'excludes Coding not in VS messages' do
-      oo = FHIR::OperationOutcome.new(
-        issue: [
-          {
-            severity: 'error',
-            code: 'code-invalid',
-            details: {
-              text: 'The Coding provided (urn:oid:2.16.840.1.113883.6.238#2106-3) is not in the value set ' \
-                    'http://hl7.org/fhir/us/core/ValueSet/omb-race-category, and a code is required from ' \
-                    'this value set. (error message = Not in value set ' \
-                    'http://hl7.org/fhir/us/core/ValueSet/omb-race-category)'
-            },
-            expression: [
-              'Patient.extension[0].extension[0].value.ofType(Coding)'
-            ]
-          }
-        ]
-      )
-      stub_request(:post, "#{validator_url}/validate?profile=PROFILE")
-        .to_return(status: 200, body: oo.to_json)
-
-      expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
-      expect(runnable.messages.length).to be_zero
-    end
-  end
-
   describe 'with HL7 validator wrapper' do
     before do
-      reset_g10_validators(true)
+      reset_g10_validators
     end
 
     let(:runnable) { ONCCertificationG10TestKit::G10CertificationSuite.groups.first.groups.first.tests.first.new }


### PR DESCRIPTION
Removes all logic and settings specific to the legacy inferno-validator-wrapper. Now that we've been using the HL7 validator successfully in production for a while, there's no need to keep it around.

Refer to #488 and #497 for the original changes

## Testing Guidance
Run the g10 tests as usual, there should be no visible impact to anything