### PR TITLE
Enhance docker services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       service: nginx
     volumes:
       - ./config/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - inferno
   redis:
     extends:
       file: docker-compose.background.yml


### PR DESCRIPTION
Sometimes, `inferno` is not ready when `nginx` starts and crashes because of that.
This fixes this unexpected behaviour.