### PR TITLE
FI-3915 Fix outdated link to IE Browser launch instructions in documentation.

### DIFF
--- a/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/onc_certification_g10_test_kit/smart_ehr_practitioner_app_group.rb
@@ -52,7 +52,7 @@ module ONCCertificationG10TestKit
 
       For EHRs that use Internet Explorer 11 to display embedded apps,
       please review [instructions on how to complete the EHR Practitioner App
-      test](https://github.com/onc-healthit/onc-certification-g10-test-kit/wiki/Completing-EHR-Practitioner-App-test-in-Internet-Explorer/).
+      test](https://github.com/onc-healthit/onc-certification-g10-test-kit/wiki/IE-Browser).
 
       The following implementation specifications are relevant to this scenario:
 


### PR DESCRIPTION
We reorganized the wiki, and we missed updating this link to the renamed page.  I did a search of the repo and didn't find any other links to the wiki that didn't work.

Also, I added a temporary page in the wiki manually to link people to the right spot; however, this will be wiped out the next time we make a change to the docs/ directory in the repo.

h/t @edeyoung 

Something we should consider doing is asking on Zulip if there is a need to maintain this any more.  At this point, IE is well past the sunset date; though, these types of things tend to take longer to retire in practice.
