### PR TITLE
FI-3867: Bump validator to v1.0.65

### DIFF
--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -15,7 +15,7 @@ services:
       - ./data/redis:/data
     command: redis-server --appendonly yes
   hl7_validator_service:
-    image: infernocommunity/inferno-resource-validator:1.0.60
+    image: infernocommunity/inferno-resource-validator:1.0.65
     environment:
       # Defines how long validator sessions last if unused, in minutes:
       # Negative values mean sessions never expire, 0 means sessions immediately expire

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -2,7 +2,7 @@ require_relative '../inferno/terminology/tasks/check_built_terminology'
 
 module ONCCertificationG10TestKit
   class ConfigurationChecker
-    EXPECTED_HL7_VALIDATOR_VERSION = '1.0.60'.freeze
+    EXPECTED_HL7_VALIDATOR_VERSION = '1.0.65'.freeze
     HL7_VALIDATOR_VERSION_KEY = 'validatorWrapperVersion'.freeze
 
     def configuration_messages


### PR DESCRIPTION
Bump the validator service to version 1.0.65 which is the most recent as of today. (https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/releases) This uses the core HL7 validator version 6.5.17 (https://github.com/hapifhir/org.hl7.fhir.core/releases)

This release has no breaking changes to the validation service API or configuration options, and does not introduce any new error messages for our reference server data based on testing against all 4 g10 x US Core version options. The biggest change is a new environment variable that allows for configuring the presets loaded at service startup. Our image defaults this env var such that no presets are loaded.