### PR TITLE
FI-4118: Fix terminology build

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,11 @@ to `true`, to that same file. This tells the build system to delete the "build
 files"--everything except for the finished databases--after the build.
 
 Once that file exists, you can run the terminology creation task by using the
-following command:
+following commands:
 
 ```shell
-docker compose -f terminology_compose.yml up --build
+docker buildx build --platform linux/amd64 -t onc-certification-g10-test-kit-terminology_builder:latest -f Dockerfile.terminology --load .
+docker compose -f terminology_compose.yml up
 ```
 
 This will run the terminology creation steps in order. These tasks may take

--- a/generate_terminology.sh
+++ b/generate_terminology.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+docker buildx build --platform linux/amd64 -t onc-certification-g10-test-kit-terminology_builder:latest -f Dockerfile.terminology --no-cache --load .
+docker compose -f terminology_compose.yml up

--- a/generate_terminology.sh
+++ b/generate_terminology.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-docker buildx build --platform linux/amd64 -t onc-certification-g10-test-kit-terminology_builder:latest -f Dockerfile.terminology --no-cache --load .
-docker compose -f terminology_compose.yml up

--- a/lib/inferno/terminology/fhir_package_manager.rb
+++ b/lib/inferno/terminology/fhir_package_manager.rb
@@ -73,6 +73,7 @@ module Inferno
             end
 
             puts "Downloading #{package_url}"
+            # TODO: remove verify_ssl: false
             RestClient::Request.execute(method: :get, url: package_url, block_response: block, verify_ssl: false)
           end
 

--- a/lib/inferno/terminology/fhir_package_manager.rb
+++ b/lib/inferno/terminology/fhir_package_manager.rb
@@ -11,7 +11,7 @@ module Inferno
       class << self
         REGISTRY_SERVER_URL = 'https://packages.fhir.org'.freeze
         US_CORE_7_PACKAGE_URL = 'https://hl7.org/fhir/us/core/STU7/package.tgz'.freeze
-        VSAC_18_PACKAGE_URL = 'https://packages2.fhir.org/packages/us.nlm.vsac/0.18.0'.freeze
+        VSAC_18_PACKAGE_URL = 'https://packages2.fhir.org/web//us.nlm.vsac-0.18.0.tgz'.freeze
         REQUIRED_VSAC_VALUE_SET_URLS = [
           'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836',
           'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.1.11.14914',
@@ -63,11 +63,17 @@ module Inferno
           File.open(tar_file_name, 'w') do |output_file|
             output_file.binmode
             block = proc do |response|
-              response.read_body do |chunk|
-                output_file.write chunk
+              if ['301', '302', '307'].include? response.code
+                RestClient::Request.execute(method: :get, url: response.header[:location], block_response: block)
+              else
+                response.read_body do |chunk|
+                  output_file.write chunk
+                end
               end
             end
-            RestClient::Request.execute(method: :get, url: package_url, block_response: block)
+
+            puts "Downloading #{package_url}"
+            RestClient::Request.execute(method: :get, url: package_url, block_response: block, verify_ssl: false)
           end
 
           tar = Gem::Package::TarReader.new(Zlib::GzipReader.open("tmp/#{package.split('#').join('-')}.tgz"))

--- a/terminology_compose.yml
+++ b/terminology_compose.yml
@@ -1,12 +1,7 @@
 version: '3.2'
 services:
   terminology_builder:
-    build:
-      context: .
-      dockerfile: Dockerfile.terminology
-    # Uncomment the line below if using an arm mac. For some reason
-    # metamorphosys isn't working in arm docker images.
-    # platform: 'linux/amd64'
+    image: onc-certification-g10-test-kit-terminology_builder:latest
     volumes:
       - ./data:/opt/inferno/data
       - type: bind


### PR DESCRIPTION
See (#662).

This branch updates the location of the VSAC package and also the package fetching code so that it should follow redirects. The docker build also was not working on ARM macs, so the README has been updated to address this issue.