### PR TITLE
build(terminology): use compose profiles to simplify terminology builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ Once that file exists, you can run the terminology creation task by using the
 following command:
 
 ```shell
-docker compose -f terminology_compose.yml up --build
+docker compose build terminology_builder
+docker compose run --rm terminology_builder
 ```
 
 This will run the terminology creation steps in order. These tasks may take

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,12 @@ services:
     extends:
       file: docker-compose.background.yml
       service: hl7_validator_service
+  ##
+  # Because of the `profiles` key, this service will only be started
+  # if a matching profile is specified, or if this service is explicitly named.
+  terminology_builder:
+    profiles:
+    - terminology_builder
+    extends:
+      file: terminology_compose.yml
+      service: terminology_builder


### PR DESCRIPTION
Use [docker compose profiles](https://docs.docker.com/compose/how-tos/profiles/) to avoid needing users to specify a distinct docker compose file for building terminology. Also, update the README to avoid an orphan container at the end of the terminology build process.