### PR TITLE
FI-4224 Update filter for tx.fhir.org message

### DIFF
--- a/lib/onc_certification_g10_test_kit/g10_certification_suite.rb
+++ b/lib/onc_certification_g10_test_kit/g10_certification_suite.rb
@@ -141,7 +141,7 @@ module ONCCertificationG10TestKit
       /\A\S+: \S+: A definition for CodeSystem '.*' could not be found, so the code cannot be validated/,
       /\A\S+: \S+: URL value '.*' does not resolve/,
       /\A\S+: \S+: .*\[No server available\]/, # Catch-all for certain errors when TX server is disabled
-      %r{\A\S+: \S+: .*\[Error from http://tx.fhir.org/r4:} # Catch-all for TX server errors that slip through
+      %r{\A\S+: \S+: .*\[Error from https?://tx.fhir.org/r4:} # Catch-all for TX server errors that slip through
     ].freeze
 
     def self.setup_validator(us_core_version_requirement) # rubocop:disable Metrics/CyclomaticComplexity

--- a/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
@@ -56,5 +56,29 @@ RSpec.describe 'Resource Validation' do # rubocop:disable RSpec/DescribeClass
       expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
       expect(runnable.messages.length).to be_zero
     end
+
+    it 'excludes https://tx.fhir.org/r4 message' do
+      operation_outcome = {
+        outcomes: [
+          {
+            issues: [
+              {
+                location: "DocumentReference.content[0].attachment.contentType",
+                message: "The System URI could not be determined for the code 'text/plain' in the ValueSet 'http://hl7.org/fhir/ValueSet/mimetypes|4.0.1': include #0 has system urn:ietf:bcp:13 which could not be found, and the server returned error [Error from https://tx.fhir.org/r4: The code System \"urn:ietf:bcp:13\" has a grammar, and cannot be enumerated directly]",
+                type: 'CODEINVALID',
+                level: 'ERROR'
+              }
+            ]
+          }
+        ],
+        sessionId: '7c0cb248-4dd9-4063-9ed9-03623bbe221a'
+      }
+
+      stub_request(:post, "#{validator_url}/validate")
+        .to_return(status: 200, body: operation_outcome.to_json)
+
+      expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
+      expect(runnable.messages.length).to be_zero
+    end
   end
 end


### PR DESCRIPTION
This PR fixes issue https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/524

##What's changed:
* Update filter to include `https?://` for updated validator message
* Create a unit test