### PR TITLE
FI-4224 Add another filter for mimetypes value set

### DIFF
--- a/lib/onc_certification_g10_test_kit/g10_certification_suite.rb
+++ b/lib/onc_certification_g10_test_kit/g10_certification_suite.rb
@@ -141,7 +141,9 @@ module ONCCertificationG10TestKit
       /\A\S+: \S+: A definition for CodeSystem '.*' could not be found, so the code cannot be validated/,
       /\A\S+: \S+: URL value '.*' does not resolve/,
       /\A\S+: \S+: .*\[No server available\]/, # Catch-all for certain errors when TX server is disabled
-      %r{\A\S+: \S+: .*\[Error from https?://tx.fhir.org/r4:} # Catch-all for TX server errors that slip through
+      %r{\A\S+: \S+: .*\[Error from https?://tx.fhir.org/r4:}, # Catch-all for TX server errors that slip through
+      # This is a strange error introduced by FHIR validator core 6.5.28.
+      %r{\A\S+: \S+: The System URI could not be determined for the code '.*' in the ValueSet 'http://hl7.org/fhir/ValueSet/mimetypes|4.0.1'}
     ].freeze
 
     def self.setup_validator(us_core_version_requirement) # rubocop:disable Metrics/CyclomaticComplexity

--- a/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
+++ b/spec/onc_certification_g10_test_kit/resource_validation_spec.rb
@@ -84,5 +84,30 @@ RSpec.describe 'Resource Validation' do # rubocop:disable RSpec/DescribeClass
       expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
       expect(runnable.messages.length).to be_zero
     end
+
+    it 'excludes The System URI could not be determine" message' do
+      operation_outcome = {
+        outcomes: [
+          {
+            issues: [
+              {
+                location: 'DocumentReference.content[0].attachment.contentType',
+                message: 'The System URI could not be determined for the code \'text/plain\' in the ' \
+                         'ValueSet \'http://hl7.org/fhir/ValueSet/mimetypes|4.0.1\'',
+                type: 'CODEINVALID',
+                level: 'ERROR'
+              }
+            ]
+          }
+        ],
+        sessionId: '7c0cb248-4dd9-4063-9ed9-03623bbe221a'
+      }
+
+      stub_request(:post, "#{validator_url}/validate")
+        .to_return(status: 200, body: operation_outcome.to_json)
+
+      expect(runnable.resource_is_valid?(resource:, profile_url: 'PROFILE')).to be(true)
+      expect(runnable.messages.length).to be_zero
+    end
   end
 end


### PR DESCRIPTION
This PR filters the validation error

The System URI could not be determined for the code 'xxx' in the ValueSet 'http://hl7.org/fhir/ValueSet/mimetypes|4.0.1'

which is introduced into g10 when bump validator to 6.5.28.