### PR TITLE
ID-9: Allow 401 HTTP status for invalid client_assertion_type

### DIFF
--- a/lib/onc_certification_g10_test_kit/bulk_data_authorization.rb
+++ b/lib/onc_certification_g10_test_kit/bulk_data_authorization.rb
@@ -121,7 +121,7 @@ module ONCCertificationG10TestKit
 
         post(bulk_smart_auth_info.token_url, **post_request_content)
 
-        assert_response_status(400)
+        assert_response_status([400, 401])
       end
     end
 

--- a/spec/onc_certification_g10_test_kit/bulk_data_authorization_spec.rb
+++ b/spec/onc_certification_g10_test_kit/bulk_data_authorization_spec.rb
@@ -70,13 +70,23 @@ RSpec.describe ONCCertificationG10TestKit::BulkDataAuthorization do
       result = run(runnable, input)
 
       expect(result.result).to eq('fail')
-      expect(result.result_message).to eq('Unexpected response status: expected 400, but received 200')
+      expect(result.result_message).to match(/Unexpected response status:/)
     end
 
-    it 'passes when token endpoint requires valid client_assertion_type' do
+    it 'passes when token endpoint requires valid client_assertion_type (400)' do
       stub_request(:post, bulk_token_endpoint)
         .with(body: hash_including(client_assertion_type: 'not_an_assertion_type'))
         .to_return(status: 400)
+
+      result = run(runnable, input)
+
+      expect(result.result).to eq('pass')
+    end
+
+    it 'passes when token endpoint requires valid client_assertion_type (401)' do
+      stub_request(:post, bulk_token_endpoint)
+        .with(body: hash_including(client_assertion_type: 'not_an_assertion_type'))
+        .to_return(status: 401)
 
       result = run(runnable, input)
 


### PR DESCRIPTION
# Summary

Previously, systems were required to return a 400 HTTP status in response to an invalid value in the `client_assertion_type` parameter of a backend services token request. Now, they may also return a 401 HTTP status code, as is allowed in the [corresponding test in the SMART App Launch test kit](https://github.com/inferno-framework/smart-app-launch-test-kit/blob/main/lib/smart_app_launch/backend_services_invalid_client_assertion_test.rb#L48).

# Testing Guidance

- Run the spec tests, which are updated to check that 401 is allowable
- Update a local copy of the inferno_reference_server to return 401 for an invalid `client_assertion_type` and run group 7/8 (multi-patient API STU 1/2 depending on you session choice of Bulk STU 1 or 2) using the "Inferno Reference Server preset" and updating it to point to your local reference server instance (http://localhost:8080) - NOTE there are two inputs to update: "Bulk Data FHIR URL" and "Token URL". Test 7/8.1.03 should succeed and the associated request should have returned a 401.  To change the reference server status code you can change [this block](https://github.com/inferno-framework/inferno-reference-server/blob/main/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java#L167) to
```
throw new OAuth2Exception(ErrorCode.INVALID_CLIENT,
          "Client Assertion Type should be " + JWT_BEARER_CLIENT_ASSERTION_TYPE).withResponseStatus(HttpStatus.UNAUTHORIZED);
```