### PR TITLE
ID-15: Fix asymmetric invalid refresh token test

### DIFF
--- a/lib/onc_certification_g10_test_kit/smart_invalid_token_refresh_test.rb
+++ b/lib/onc_certification_g10_test_kit/smart_invalid_token_refresh_test.rb
@@ -1,4 +1,6 @@
 module ONCCertificationG10TestKit
+  require 'smart_app_launch/client_assertion_builder'
+
   class SMARTInvalidTokenRefreshTest < Inferno::Test
     id :g10_invalid_token_refresh
     title 'Refresh token exchange fails when supplied an invalid refresh token'
@@ -26,6 +28,17 @@ module ONCCertificationG10TestKit
       if smart_auth_info.symmetric_auth?
         credentials = Base64.strict_encode64("#{smart_auth_info.client_id}:#{smart_auth_info.client_secret}")
         oauth2_headers['Authorization'] = "Basic #{credentials}"
+      elsif smart_auth_info.asymmetric_auth?
+        oauth2_params.merge!(
+          client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+          client_assertion: SMARTAppLaunch::ClientAssertionBuilder.build(
+            iss: smart_auth_info.client_id,
+            sub: smart_auth_info.client_id,
+            aud: smart_auth_info.token_url,
+            client_auth_encryption_method: smart_auth_info.encryption_algorithm,
+            custom_jwks: smart_auth_info.jwks
+          )
+        )
       else
         oauth2_params['client_id'] = smart_auth_info.client_id
       end

--- a/spec/onc_certification_g10_test_kit/smart_invalid_token_refresh_test_spec.rb
+++ b/spec/onc_certification_g10_test_kit/smart_invalid_token_refresh_test_spec.rb
@@ -40,6 +40,46 @@ RSpec.describe ONCCertificationG10TestKit::SMARTInvalidTokenRefreshTest do
     expect(result.result).to eq('pass')
   end
 
+  context 'with asymmetric authentication' do
+    let(:default_inputs) do
+      {
+        smart_auth_info: Inferno::DSL::AuthInfo.new(
+          token_url: 'http://example.com/token',
+          client_id: 'CLIENT_ID',
+          client_secret: 'CLIENT_SECRET',
+          refresh_token: 'REFRESH_TOKEN',
+          auth_type: 'asymmetric',
+          jwks: 'JWKS',
+          encryption_algorithm: 'ES384'
+        ),
+        received_scopes: 'offline_access'
+      }
+    end
+
+    it 'uses a client assertion' do
+      stub_request(:post, default_inputs[:smart_auth_info].token_url)
+        .with do |request|
+          params = URI.decode_www_form(request.body).to_h
+          params['client_assertion'] == 'CLIENT_ASSERTION' &&
+            params['client_assertion_type'] == 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+        end
+        .to_return(status: 400)
+
+      allow(SMARTAppLaunch::ClientAssertionBuilder).to receive(:build).and_return('CLIENT_ASSERTION')
+
+      result = run(test, default_inputs)
+
+      expect(result.result).to eq('pass')
+      expect(SMARTAppLaunch::ClientAssertionBuilder).to have_received(:build).with(
+        iss: 'CLIENT_ID',
+        sub: 'CLIENT_ID',
+        aud: 'http://example.com/token',
+        client_auth_encryption_method: 'ES384',
+        custom_jwks: 'JWKS'
+      )
+    end
+  end
+
   it 'passes if the token request returns a 401' do
     stub_request(:post, default_inputs[:smart_auth_info].token_url)
       .to_return(status: 401)


### PR DESCRIPTION
### Description
This PR addresses Issue #700 by fixing the **SMARTInvalidTokenRefreshTest** to support asymmetric authentication. Previously, the test did not interpret the asymmetric auth type correctly and failed to send the required **client_assertion** and **client_assertion_type** parameters. This meant the test was effectively checking unauthenticated behavior rather than authenticated asymmetric behavior.

### Changes
- **Modified** 
    **lib/onc_certification_g10_test_kit/smart_invalid_token_refresh_test.rb** to use **SMARTAppLaunch::ClientAssertionBuilder** for generating the client assertion when asymmetric auth is configured. Updated **spec/onc_certification_g10_test_kit/smart_invalid_token_refresh_test_spec.rb** with a new context to verify the presence of client assertion parameters in the request.

- **Updated** 
    **spec/onc_certification_g10_test_kit/smart_invalid_token_refresh_test_spec.rb** with a new context to verify the presence of client assertion parameters in the request.

### End-to-End Testing Steps
1. **Start Inferno:** 
    - Launch the **onc-certification-g10-test-kit** instance.

2. **Select Options:**
    - On the home page, select **US Core 6.1.0 / USCDI v3**.
    - Select **SMART App Launch 2.0.0**.
    - Select **Bulk Data 1.0.1**.
    - Click **START TESTING** button.

3. **Select Preset:**
    - In the top-left corner of the test session, locate the Preset dropdown.
    - Select Inferno Reference Server Preset.
    - This will auto-populate the necessary configuration fields.

4. **Navigate to Test:**
    - Expand **9 Additional Authorization Tests** in the left sidebar.
    - Expand **9.12 Asymmetric Client Launch**.
    - Expand **9.12.3 Token Refresh**.

5. **Run Test:**
    - Click the **RUN TESTS** button in the top right.
    - Action: In the **Asymmetric Client Standalone Launch** modal that appears, click the **Submit** button (inputs are pre-filled by the preset).

6. **Verify:**

    - Ensure test **9.12.3.06** PASSES.
    - Click on the **9.12.3.06** test result to expand details.
    - Check the **Requests** tab for the POST to the token endpoint.
    - Confirm the request body includes **client_assertion** and **client_assertion_type**.