### PR TITLE
Release 8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# 7.3.0
-* Remove versions of US Core and SMART that are below current certification minimums
+# 8.0.0
+* Upgrade inferno-core
+* Remove versions of US Core (3.1.1 and 4.0.0) and SMART (1.0.0) that are below current certification minimums
 
 # 7.2.9
 * Update dependency of inferno-core to v1.0.8 (empty Bundle.entry.resource handling)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    onc_certification_g10_test_kit (7.3.0)
+    onc_certification_g10_test_kit (8.0.0)
       bloomer (~> 1.0.0)
       colorize (~> 0.8.1)
-      inferno_core (~> 1.0, >= 1.0.8)
+      inferno_core (~> 1.1)
       json-jwt (~> 1.15.3)
       mime-types (~> 3.4.0)
       ndjson (~> 1.0.0)
@@ -152,7 +152,7 @@ GEM
       mutex_m
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    inferno_core (1.0.8)
+    inferno_core (1.1.0)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)

--- a/lib/onc_certification_g10_test_kit/version.rb
+++ b/lib/onc_certification_g10_test_kit/version.rb
@@ -1,4 +1,4 @@
 module ONCCertificationG10TestKit
-  VERSION = '7.3.0'.freeze
-  LAST_UPDATED = '2026-03-05'.freeze # TODO: update next release
+  VERSION = '8.0.0'.freeze
+  LAST_UPDATED = '2026-03-09'.freeze # TODO: update next release
 end

--- a/onc_certification_g10_test_kit.gemspec
+++ b/onc_certification_g10_test_kit.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache-2.0'
   spec.add_dependency 'bloomer', '~> 1.0.0'
   spec.add_dependency 'colorize', '~> 0.8.1'
-  spec.add_dependency 'inferno_core', '~> 1.0', '>= 1.0.8'
+  spec.add_dependency 'inferno_core', '~> 1.1'
   spec.add_dependency 'json-jwt', '~> 1.15.3'
   spec.add_dependency 'mime-types', '~> 3.4.0'
   spec.add_dependency 'ndjson', '~> 1.0.0'


### PR DESCRIPTION
## Proposed Release Notes

The ONC Certification (g)(10) Standardized API Test Kit v8.0.0 is a major update which removes support for the following IG versions which are no longer available for certification.
- US Core 3.1.1 / USCDI v1
- US Core 4.0.0 / USCDI v1
- SMART App Launch 1.0.0 

This update also updates the default scopes requested by Inferno to follow US Core 6.1.0 / USCDI v3.
