### PR TITLE
Release v8.0.3 for Validator v1.0.79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 8.0.3
+* Update expected validator version to 1.0.79
+
 # 8.0.2
 * ID-45: Execution Scripts by @karlnaden in https://github.com/onc-healthit/onc-certification-g10-test-kit/pull/752
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    onc_certification_g10_test_kit (8.0.2)
+    onc_certification_g10_test_kit (8.0.3)
       bloomer (~> 1.0.0)
       colorize (~> 0.8.1)
       inferno_core (~> 1.2, >= 1.2.2)

--- a/lib/onc_certification_g10_test_kit/configuration_checker.rb
+++ b/lib/onc_certification_g10_test_kit/configuration_checker.rb
@@ -2,7 +2,7 @@ require_relative '../inferno/terminology/tasks/check_built_terminology'
 
 module ONCCertificationG10TestKit
   class ConfigurationChecker
-    EXPECTED_HL7_VALIDATOR_VERSION = '1.0.78'.freeze
+    EXPECTED_HL7_VALIDATOR_VERSION = '1.0.79'.freeze
     HL7_VALIDATOR_VERSION_KEY = 'validatorWrapperVersion'.freeze
 
     def configuration_messages

--- a/lib/onc_certification_g10_test_kit/version.rb
+++ b/lib/onc_certification_g10_test_kit/version.rb
@@ -1,4 +1,4 @@
 module ONCCertificationG10TestKit
-  VERSION = '8.0.2'.freeze
-  LAST_UPDATED = '2026-05-27'.freeze # TODO: update next release
+  VERSION = '8.0.3'.freeze
+  LAST_UPDATED = '2026-07-07'.freeze # TODO: update next release
 end


### PR DESCRIPTION
Update the target validator version to 1.0.79.

## Testing Instructions

Start the g10 tests locally and Run the execution scripts to confirm no regressions.